### PR TITLE
Allow to change `URLSessionConfiguration` for uploading signals

### DIFF
--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -19,10 +19,13 @@ internal class SignalManager: SignalManageable {
 
     private var signalCache: SignalCache<SignalPostBody>
     let configuration: TelemetryManagerConfiguration
+    private let urlSession: URLSession
     private var sendTimer: Timer?
 
     init(configuration: TelemetryManagerConfiguration) {
         self.configuration = configuration
+
+        urlSession = URLSession(configuration: configuration.urlSessionConfiguration)
 
         // We automatically load any old signals from disk on initialisation
         signalCache = SignalCache(logHandler: configuration.logHandler)
@@ -183,10 +186,7 @@ private extension SignalManager {
             self.configuration.logHandler?.log(.debug, message: String(data: urlRequest.httpBody!, encoding: .utf8)!)
 
             /// Wait for connectivity
-            let config = URLSessionConfiguration.default
-            config.waitsForConnectivity = true
-            let session = URLSession(configuration: config)
-            let task = session.dataTask(with: urlRequest, completionHandler: completionHandler)
+            let task = self.urlSession.dataTask(with: urlRequest, completionHandler: completionHandler)
             task.resume()
         }
     }

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -126,6 +126,32 @@ public final class TelemetryManagerConfiguration {
     /// Defaults to an empty array.
     public var metadataEnrichers: [SignalEnricher] = []
 
+    /// The ``URLSessionConfiguration`` to use for sending signals.
+    ///
+    /// You can use this to set a custom `URLSessionConfiguration`,
+    /// which can be useful for e.g.
+    /// - providing a background session configuration instead,
+    /// - changing configuration values like `tlsMinimumSupportedProtocol`,
+    ///   if your app has to comply with certain security standards.
+    ///
+    /// The actual ``URLSession`` used for sending signals will be created
+    /// on base of this configuration, but stays private to `SignalManager`.
+    /// 
+    /// Defaults to a URLSession on base of the default configuration.
+    ///
+    /// - Note: `waitsForConnectivity` will be always overriden and set
+    ///   to `true`. 
+    ///
+    public lazy var urlSessionConfiguration: URLSessionConfiguration = {
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        return config
+    }() {
+        willSet {
+            newValue.waitsForConnectivity = true
+        }
+    }
+
     public init(appID: String, salt: String? = nil, baseURL: URL? = nil) {
         telemetryAppID = appID
 


### PR DESCRIPTION
## Motivation

Use a background URL session via [`URLSessionConfiguration.background(withIdentifier:)`](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1407496-background).

## Status

I haven't gotten around yet to put this into practice. PR'ing this already for visibility and bike-shedding around design decisions.

### Todos:
* [ ] Actually try this out with a background session
