### PR TITLE
Add structured logging as an alternative to stdout printing

### DIFF
--- a/Sources/TelemetryClient/LogHandler.swift
+++ b/Sources/TelemetryClient/LogHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 public struct LogHandler {
     public enum LogLevel: Int, CustomStringConvertible {
@@ -16,6 +17,17 @@ public struct LogHandler {
                 return "ERROR"
             }
         }
+
+        public var osLogLevel: OSLogType {
+            switch self {
+            case .debug: 
+                return OSLogType.debug
+            case .info:
+                return OSLogType.info
+            case .error:
+                return OSLogType.error
+            }
+        }
     }
 
     let logLevel: LogLevel
@@ -29,6 +41,16 @@ public struct LogHandler {
     internal func log(_ level: LogLevel = .info, message: String) {
         if level.rawValue >= logLevel.rawValue {
             handler(level, message)
+        }
+    }
+
+    @available(iOS 14.0, macOS 11.0, watchOS 7.0, tvOS 14.0, *)
+    public static var oslog = { logLevel in
+        LogHandler(logLevel: logLevel) { level, message in
+            Logger(
+                subsystem: "TelemetryDeck",
+                category: "LogHandler"
+            ).log(level: logLevel.osLogLevel, "\(message, privacy: .public)")
         }
     }
 


### PR DESCRIPTION
This fixes #131 and adds a `oslog` handler for logging as an option.

Rather than change all logging to use this new endpoint by default I left it as an option for the client to decide as perhaps people could be relying on stdout printing.

The new variable is gated around the platforms which support this new structured logging API (iOS 14 and similar).