### PR TITLE
Create explicit public initializer for LogHandler struct

### DIFF
--- a/Sources/TelemetryClient/LogHandler.swift
+++ b/Sources/TelemetryClient/LogHandler.swift
@@ -21,6 +21,11 @@ public struct LogHandler {
     let logLevel: LogLevel
     let handler: (LogLevel, String) -> Void
 
+    public init(logLevel: LogLevel, handler: @escaping (LogLevel, String) -> Void) {
+        self.logLevel = logLevel
+        self.handler = handler
+    }
+
     internal func log(_ level: LogLevel = .info, message: String) {
         if level.rawValue >= logLevel.rawValue {
             handler(level, message)


### PR DESCRIPTION
This adds an explicit public initializer to replace the implicit internal one.

Fixes #151 