### PR TITLE
Mark global navigation as @MainActor to avoid data-race safety issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://editorconfig.org
+root = true
+
+[*]
+
+indent_style = space
+tab_width = 8
+indent_size = 4
+
+end_of_line = lf
+insert_final_newline = true
+
+max_line_length = 160
+trim_trailing_whitespace = true

--- a/Package.swift
+++ b/Package.swift
@@ -19,15 +19,18 @@ let package = Package(
         .target(
             name: "TelemetryDeck",
             dependencies: ["TelemetryClient"],
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
         .target(
             name: "TelemetryClient",
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
         .testTarget(
             name: "TelemetryClientTests",
-            dependencies: ["TelemetryClient"]
+            dependencies: ["TelemetryClient"],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         )
     ]
 )

--- a/Sources/TelemetryClient/Presets/NavigationStatus.swift
+++ b/Sources/TelemetryClient/Presets/NavigationStatus.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// This internal singleton keeps track of the last used navigation path so
 /// that the ``TelemetryDeck.navigationPathChanged(to:customUserID:)`` function has a `from` source to work off of.
+@MainActor
 class NavigationStatus {
     static let shared = NavigationStatus()
 

--- a/Sources/TelemetryClient/Presets/TelemetryDeck+Navigation.swift
+++ b/Sources/TelemetryClient/Presets/TelemetryDeck+Navigation.swift
@@ -19,6 +19,7 @@ extension TelemetryDeck {
     ///     - from: The navigation path at the beginning of the navigation event, identifying the view the user is leaving
     ///     - to: The navigation path at the end of the navigation event, identifying the view the user is arriving at
     ///     - customUserID: An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration. Default is `nil`.
+    @MainActor
     public static func navigationPathChanged(from source: String, to destination: String, customUserID: String? = nil) {
         NavigationStatus.shared.previousNavigationPath = destination
 
@@ -57,17 +58,20 @@ extension TelemetryDeck {
     /// - Parameters:
     ///     - to: The navigation path representing the view the user is arriving at.
     ///     - customUserID: An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration. Default is `nil`.
+    @MainActor
     public static func navigationPathChanged(to destination: String, customUserID: String? = nil) {
         let source = NavigationStatus.shared.previousNavigationPath ?? ""
 
         Self.navigationPathChanged(from: source, to: destination, customUserID: customUserID)
     }
 
+    @MainActor
     @available(*, unavailable, renamed: "navigationPathChanged(from:to:customUserID:)")
     public static func navigate(from source: String, to destination: String, customUserID: String? = nil) {
         self.navigationPathChanged(from: source, to: destination, customUserID: customUserID)
     }
 
+    @MainActor
     @available(*, unavailable, renamed: "navigationPathChanged(to:customUserID:)")
     public static func navigate(to destination: String, customUserID: String? = nil) {
         self.navigationPathChanged(to: destination, customUserID: customUserID)


### PR DESCRIPTION
This fixes https://github.com/TelemetryDeck/SwiftSDK/issues/172.

This can be considered a first step into https://github.com/TelemetryDeck/SwiftSDK/issues/165 to make the SDK ready for Swift 6 mode. To make sure we keep the data-race safety for the navigation path, I've additionally turned on strict-concurrency-checking, which also gives us warnings for all the places that will become errors in Swift 6 mode.

Note that I have also added an `.editorconfig` file in this PR to codify the existing indentation config in the project. See my tweet to learn more about this new feature in Xcode 16: https://x.com/Jeehut/status/1817931035872751744