### PR TITLE
Add full data-race safety and enable strict concurrency checking for Swift 6 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://editorconfig.org
+root = true
+
+[*]
+
+indent_style = space
+tab_width = 8
+indent_size = 4
+
+end_of_line = lf
+insert_final_newline = true
+
+max_line_length = 160
+trim_trailing_whitespace = true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -19,15 +19,18 @@ let package = Package(
         .target(
             name: "TelemetryDeck",
             dependencies: ["TelemetryClient"],
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
         .target(
             name: "TelemetryClient",
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
         .testTarget(
             name: "TelemetryClientTests",
-            dependencies: ["TelemetryClient"]
+            dependencies: ["TelemetryClient"],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         )
     ]
 )

--- a/Sources/TelemetryClient/JSONFormatting.swift
+++ b/Sources/TelemetryClient/JSONFormatting.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 extension Formatter {
-    static let iso8601: ISO8601DateFormatter = {
+    static var iso8601: ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
-    }()
+    }
 
-    static let iso8601noFS = ISO8601DateFormatter()
+    static var iso8601noFS: ISO8601DateFormatter { ISO8601DateFormatter() }
 
-    static let iso8601dateOnly: ISO8601DateFormatter = {
+    static var iso8601dateOnly: ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withFullDate]
         return formatter
-    }()
+    }
 }
 
 extension JSONDecoder.DateDecodingStrategy {
@@ -28,7 +28,7 @@ extension JSONDecoder.DateDecodingStrategy {
 }
 
 extension JSONDecoder {
-    static var telemetryDecoder: JSONDecoder = {
+    static var telemetryDecoder: JSONDecoder {
         let decoder = JSONDecoder()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
@@ -36,17 +36,17 @@ extension JSONDecoder {
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
         return decoder
-    }()
+    }
 
-    static var druidDecoder: JSONDecoder = {
+    static var druidDecoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .customISO8601
         return decoder
-    }()
+    }
 }
 
 extension JSONEncoder {
-    static var telemetryEncoder: JSONEncoder = {
+    static var telemetryEncoder: JSONEncoder {
         let encoder = JSONEncoder()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
@@ -54,7 +54,7 @@ extension JSONEncoder {
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         encoder.dateEncodingStrategy = .formatted(dateFormatter)
         return encoder
-    }()
+    }
 }
 
 extension Data {

--- a/Sources/TelemetryClient/LogHandler.swift
+++ b/Sources/TelemetryClient/LogHandler.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct LogHandler {
-    public enum LogLevel: Int, CustomStringConvertible {
+public struct LogHandler: Sendable {
+    public enum LogLevel: Int, CustomStringConvertible, Sendable {
         case debug = 0
         case info = 1
         case error = 2
@@ -19,9 +19,9 @@ public struct LogHandler {
     }
 
     let logLevel: LogLevel
-    let handler: (LogLevel, String) -> Void
+    let handler: @Sendable (LogLevel, String) -> Void
 
-    public init(logLevel: LogHandler.LogLevel, handler: @escaping (LogHandler.LogLevel, String) -> Void) {
+    public init(logLevel: LogHandler.LogLevel, handler: @escaping @Sendable (LogHandler.LogLevel, String) -> Void) {
         self.logLevel = logLevel
         self.handler = handler
     }
@@ -32,7 +32,7 @@ public struct LogHandler {
         }
     }
 
-    public static var stdout = { logLevel in
+    public static func stdout(_ logLevel: LogLevel) -> LogHandler {
         LogHandler(logLevel: logLevel) { level, message in
             print("[TelemetryDeck: \(level.description)] \(message)")
         }

--- a/Sources/TelemetryClient/Presets/NavigationStatus.swift
+++ b/Sources/TelemetryClient/Presets/NavigationStatus.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// This internal singleton keeps track of the last used navigation path so
 /// that the ``TelemetryDeck.navigationPathChanged(to:customUserID:)`` function has a `from` source to work off of.
+@MainActor
 class NavigationStatus {
     static let shared = NavigationStatus()
 

--- a/Sources/TelemetryClient/Presets/TelemetryDeck+Navigation.swift
+++ b/Sources/TelemetryClient/Presets/TelemetryDeck+Navigation.swift
@@ -19,6 +19,7 @@ extension TelemetryDeck {
     ///     - from: The navigation path at the beginning of the navigation event, identifying the view the user is leaving
     ///     - to: The navigation path at the end of the navigation event, identifying the view the user is arriving at
     ///     - customUserID: An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration. Default is `nil`.
+    @MainActor
     public static func navigationPathChanged(from source: String, to destination: String, customUserID: String? = nil) {
         NavigationStatus.shared.previousNavigationPath = destination
 
@@ -57,17 +58,20 @@ extension TelemetryDeck {
     /// - Parameters:
     ///     - to: The navigation path representing the view the user is arriving at.
     ///     - customUserID: An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration. Default is `nil`.
+    @MainActor
     public static func navigationPathChanged(to destination: String, customUserID: String? = nil) {
         let source = NavigationStatus.shared.previousNavigationPath ?? ""
 
         Self.navigationPathChanged(from: source, to: destination, customUserID: customUserID)
     }
 
+    @MainActor
     @available(*, unavailable, renamed: "navigationPathChanged(from:to:customUserID:)")
     public static func navigate(from source: String, to destination: String, customUserID: String? = nil) {
         self.navigationPathChanged(from: source, to: destination, customUserID: customUserID)
     }
 
+    @MainActor
     @available(*, unavailable, renamed: "navigationPathChanged(to:customUserID:)")
     public static func navigate(to destination: String, customUserID: String? = nil) {
         self.navigationPathChanged(to: destination, customUserID: customUserID)

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -41,6 +41,7 @@ internal struct SignalPostBody: Codable, Equatable {
 
 /// The default payload that is included in payloads processed by TelemetryDeck.
 public struct DefaultSignalPayload: Encodable {
+    @MainActor
     public static var parameters: [String: String] {
         var parameters: [String: String] = [
             // deprecated names
@@ -338,6 +339,7 @@ extension DefaultSignalPayload {
     }
 
     /// The current devices screen resolution width in points.
+    @MainActor
     static var screenResolutionWidth: String {
         #if os(iOS) || os(tvOS)
         return "\(UIScreen.main.bounds.width)"
@@ -354,6 +356,7 @@ extension DefaultSignalPayload {
     }
 
     /// The current devices screen resolution height in points.
+    @MainActor
     static var screenResolutionHeight: String {
         #if os(iOS) || os(tvOS)
         return "\(UIScreen.main.bounds.height)"
@@ -370,6 +373,7 @@ extension DefaultSignalPayload {
     }
 
     /// The current devices screen orientation. Returns `Fixed` for devices that don't support an orientation change.
+    @MainActor
     static var orientation: String {
         #if os(iOS)
         switch UIDevice.current.orientation {

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -7,7 +7,7 @@ import Foundation
 /// correctly.
 ///
 /// Currently the cache is only in-memory. This will probably change in the near future.
-internal class SignalCache<T> where T: Codable {
+internal class SignalCache<T>: @unchecked Sendable where T: Codable {
     internal var logHandler: LogHandler?
 
     private var cachedSignals: [T] = []

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -13,7 +13,7 @@ internal class SignalCache<T>: @unchecked Sendable where T: Codable {
     private var cachedSignals: [T] = []
     private let maximumNumberOfSignalsToPopAtOnce = 100
 
-    let queue = DispatchQueue(label: "telemetrydeck-signal-cache", attributes: .concurrent)
+    let queue = DispatchQueue(label: "com.telemetrydeck.SignalCache", attributes: .concurrent)
 
     /// How many Signals are cached
     func count() -> Int {

--- a/Sources/TelemetryClient/SignalEnricher.swift
+++ b/Sources/TelemetryClient/SignalEnricher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol SignalEnricher {
+public protocol SignalEnricher: Sendable {
     func enrich(
         signalType: String,
         for clientUser: String?,

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -15,11 +15,12 @@ internal protocol SignalManageable {
     func attemptToSendNextBatchOfCachedSignals()
 }
 
-internal class SignalManager: SignalManageable {
+internal final class SignalManager: SignalManageable, @unchecked Sendable {
     internal static let minimumSecondsToPassBetweenRequests: Double = 10
 
     private var signalCache: SignalCache<SignalPostBody>
     let configuration: TelemetryManagerConfiguration
+
     private var sendTimer: Timer?
 
     init(configuration: TelemetryManagerConfiguration) {
@@ -175,7 +176,7 @@ private extension SignalManager {
 // MARK: - Comms
 
 private extension SignalManager {
-    private func send(_ signalPostBodies: [SignalPostBody], completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
+    private func send(_ signalPostBodies: [SignalPostBody], completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) {
         DispatchQueue.global(qos: .utility).async {
             let path = "/api/v1/apps/\(self.configuration.telemetryAppID)/signals/multiple/"
             let url = self.configuration.apiBaseURL.appendingPathComponent(path)

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -104,6 +104,7 @@ internal final class SignalManager: SignalManageable, @unchecked Sendable {
     /// Sends one batch of signals from the cache if not empty.
     /// If signals fail to send, we put them back into the cache to try again later.
     @objc
+    @Sendable
     internal func attemptToSendNextBatchOfCachedSignals() {
         configuration.logHandler?.log(.debug, message: "Current signal cache count: \(signalCache.count())")
 

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -195,7 +195,7 @@ public struct TelemetryManagerConfiguration: Sendable {
 /// Accepts signals that signify events in your app's life cycle, collects and caches them, and pushes them to the Telemetry API.
 ///
 /// Use an instance of `TelemetryManagerConfiguration` to configure this at initialization and during its lifetime.
-public class TelemetryManager {
+public final class TelemetryManager: @unchecked Sendable {
     /// Returns `true` when the TelemetryManager already has been initialized correctly, `false` otherwise.
     public static var isInitialized: Bool {
         initializedTelemetryManager != nil
@@ -350,6 +350,7 @@ public class TelemetryManager {
         self.signalManager = signalManager
     }
 
+    nonisolated(unsafe)
     private static var initializedTelemetryManager: TelemetryManager?
 
     private var configuration: TelemetryManagerConfiguration

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -17,7 +17,7 @@ let telemetryClientVersion = "2.3.0"
 /// Use an instance of this class to specify settings for TelemetryManager. If these settings change during the course of
 /// your runtime, it might be a good idea to hold on to the instance and update it as needed. TelemetryManager's behaviour
 /// will update as well.
-public final class TelemetryManagerConfiguration {
+public struct TelemetryManagerConfiguration: Sendable {
     /// Your app's ID for Telemetry. Set this during initialization.
     public let telemetryAppID: String
 
@@ -352,7 +352,7 @@ public class TelemetryManager {
 
     private static var initializedTelemetryManager: TelemetryManager?
 
-    private let configuration: TelemetryManagerConfiguration
+    private var configuration: TelemetryManagerConfiguration
 
     private let signalManager: SignalManageable
 

--- a/Tests/TelemetryClientTests/LogHandlerTests.swift
+++ b/Tests/TelemetryClientTests/LogHandlerTests.swift
@@ -2,15 +2,16 @@
 import XCTest
 
 final class LogHandlerTests: XCTestCase {
+    var counter: Int = 0
+    var lastLevel: LogHandler.LogLevel?
+
     func testLogHandler_stdoutLogLevelDefined() {
         XCTAssertEqual(LogHandler.stdout(.error).logLevel, .error)
     }
     
     func testLogHandler_logLevelRespected() {
-        var counter = 0
-        
         let handler = LogHandler(logLevel: .info) { _, _ in
-            counter += 1
+            self.counter += 1
         }
         
         XCTAssertEqual(counter, 0)
@@ -23,10 +24,8 @@ final class LogHandlerTests: XCTestCase {
     }
     
     func testLogHandler_defaultLogLevel() {
-        var lastLevel: LogHandler.LogLevel?
-        
         let handler = LogHandler(logLevel: .debug) { level, _ in
-            lastLevel = level
+            self.lastLevel = level
         }
         
         handler.log(message: "")

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -172,6 +172,7 @@ private class FakeSignalManager: SignalManageable {
     var processedSignalTypes = [String]()
     var processedSignals = [SignalPostBody]()
     
+    @MainActor
     func processSignal(_ signalType: String, parameters: [String : String], floatValue: Double?, customUserID: String?, configuration: TelemetryManagerConfiguration) {
         processedSignalTypes.append(signalType)
         let enrichedMetadata: [String: String] = configuration.metadataEnrichers

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -61,7 +61,7 @@ final class TelemetryClientTests: XCTestCase {
             }
         }
         
-        let configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
+        var configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
         configuration.metadataEnrichers.append(BasicEnricher())
         
         let signalManager = FakeSignalManager()
@@ -81,7 +81,7 @@ final class TelemetryClientTests: XCTestCase {
             }
         }
         
-        let configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
+        var configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
         configuration.metadataEnrichers.append(BasicEnricher())
         
         let signalManager = FakeSignalManager()
@@ -111,7 +111,7 @@ final class TelemetryClientTests: XCTestCase {
     func testSendsSignals_withAnalyticsExplicitlyEnabled() {
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        var configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
         configuration.analyticsDisabled = false
         
         let signalManager = FakeSignalManager()
@@ -125,7 +125,7 @@ final class TelemetryClientTests: XCTestCase {
     func testDoesNotSendSignals_withAnalyticsExplicitlyDisabled() {
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        var configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
         configuration.analyticsDisabled = true
         
         let signalManager = FakeSignalManager()
@@ -141,7 +141,7 @@ final class TelemetryClientTests: XCTestCase {
 
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        var configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
         configuration.analyticsDisabled = false
         
         let signalManager = FakeSignalManager()


### PR DESCRIPTION
Implements #165.

Note that this is based off of the branch of #173 and therefore supersedes it. If this is merged first, #173 can be closed.

You might want to also check out my article in https://github.com/TelemetryDeck/docs/pull/98 to understand the changes better.

Also, it's probably a good idea if a few real-world customers give these changes a spin, either by including the `feature/data-race-safety` branch or on the `main` branch once this is merged. We should have some real-world testing before making a regular release.