### PR TITLE
Add error wrapper to conform any error type to IdentifiableError

### DIFF
--- a/Sources/TelemetryClient/Presets/AnyIdentifiableError.swift
+++ b/Sources/TelemetryClient/Presets/AnyIdentifiableError.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// A generic wrapper that conforms any error to ``IdentifiableError``, exposing its `localizedDescription` as the `message`.
+public struct AnyIdentifiableError: LocalizedError, IdentifiableError {
+    /// Unique identifier for the error, such as `TelemetryDeck.Session.started`.
+    public let id: String
+
+    /// The underlying error being wrapped.
+    public let error: any Error
+
+    /// Initializes with a given `id` and `error`.
+    /// - Parameters:
+    ///   - id: Unique identifier for the error, such as `TelemetryDeck.Session.started`.
+    ///   - error: The error to be wrapped.
+    public init(id: String, error: any Error) {
+        self.id = id
+        self.error = error
+    }
+
+    /// Provides the localized description of the wrapped error.
+    public var errorDescription: String {
+        self.error.localizedDescription
+    }
+}
+
+extension Error {
+    /// Wraps any caught error with an `id` for use with ``TelemetryDeck.signal(identifiableError:)``.
+    /// - Parameters:
+    ///   - id: Unique identifier for the error, such as `TelemetryDeck.Session.started`.
+    /// - Returns: An ``AnyIdentifiableError`` instance wrapping the given error.
+    public func with(id: String) -> AnyIdentifiableError {
+        AnyIdentifiableError(id: id, error: self)
+    }
+}

--- a/Sources/TelemetryClient/Presets/TelemetryDeck+Errors.swift
+++ b/Sources/TelemetryClient/Presets/TelemetryDeck+Errors.swift
@@ -39,7 +39,7 @@ public extension TelemetryDeck {
     /// Sends a telemetry signal indicating that an identifiable error has occurred.
     ///
     /// - Parameters:
-    ///   - identifiableError: The error that conforms to `IdentifiableError`.
+    ///   - identifiableError: The error that conforms to `IdentifiableError`. Conform any error type by calling `.with(id:)` on it.
     ///   - category: The category of the error. Default is `.thrownException`.
     ///   - parameters: Additional parameters to include with the signal. Default is an empty dictionary.
     ///   - floatValue: An optional floating-point value to include with the signal. Default is `nil`.


### PR DESCRIPTION
This significantly improves the ease of use of the new error handling preset in the SwiftSDK. I wrote the helper added in this PR in my last app and it saved me a lot of repetitive code. I think it would make sense to ship as part of the SDK.

If merged, I can update the docs accordingly.

With this PR merged, rather than writing something like this every time I catch an error:

```swift
do {
  // ...
} catch {
  TelemetryDeck.errorOccurred(
    id: "SeriesRenamer.loadItemFailed", 
    category: .thrownException, 
    message: error.localizedDescription
  )
}
```

I can write this instead, saving unnecessary typing in many places:

```swift
do {
  // ...
} catch {
  TelemetryDeck.errorOccurred(
    identifiableError: error.with(id: "SeriesRenamer.loadItemFailed")
  )
}
```