### PR TITLE
Avoid blocking main thread for backupCache calls when leaving app

### DIFF
--- a/Sources/TelemetryDeck/Signals/SignalManager.swift
+++ b/Sources/TelemetryDeck/Signals/SignalManager.swift
@@ -151,7 +151,10 @@ private extension SignalManager {
     @objc func appWillTerminate() {
         configuration.logHandler?.log(.debug, message: #function)
 
-        // run backup in background task to avoid blocking main thread while ensureing app stays open during write
+        #if os(watchOS) || os(macOS)
+        self.signalCache.backupCache()
+        #else
+        // run backup in background task to avoid blocking main thread while ensuring app stays open during write
         let backgroundTaskID = UIApplication.shared.beginBackgroundTask()
         DispatchQueue.global(qos: .background).async {
             self.signalCache.backupCache()
@@ -160,6 +163,7 @@ private extension SignalManager {
                 UIApplication.shared.endBackgroundTask(backgroundTaskID)
             }
         }
+        #endif
     }
 
     /// WatchOS doesn't have a notification before it's killed, so we have to use background/foreground
@@ -185,7 +189,10 @@ private extension SignalManager {
         sendTimer?.invalidate()
         sendTimer = nil
 
-        // run backup in background task to avoid blocking main thread while ensureing app stays open during write
+        #if os(watchOS) || os(macOS)
+        self.signalCache.backupCache()
+        #else
+        // run backup in background task to avoid blocking main thread while ensuring app stays open during write
         let backgroundTaskID = UIApplication.shared.beginBackgroundTask()
         DispatchQueue.global(qos: .background).async {
             self.signalCache.backupCache()
@@ -194,6 +201,7 @@ private extension SignalManager {
                 UIApplication.shared.endBackgroundTask(backgroundTaskID)
             }
         }
+        #endif
     }
     #endif
 }


### PR DESCRIPTION
I tried different approaches to fix #137, even completely converting the entire `SignalCache` to an `actor`. But this caused problems with the `SignalManager` initializer requiring to be `async`, also it was not compatible with iOS 12.

But after a bit of research I came across the `beginBackgroundTask` API which seems to have been invented for exactly purposes like these: We want to write a file to disk exactly when the app is left by the user (and could be killed anytime).

According to the [docs](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtask):

> This method requests additional background execution time for your app. Call this method when leaving a task unfinished might be detrimental to your app’s user experience. For example, **_call this method before writing data to a file to prevent the system from suspending your app_** while the operation is in progress.

I've never used this API before, so I'm not an expert. But it sounds like it fits perfectly. Let me know what you think!