### PR TITLE
Add support for OSLog and default to it on modern systems

### DIFF
--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -122,10 +122,10 @@ public struct TelemetryManagerConfiguration: Sendable {
 
     /// A strategy for handling logs.
     ///
-    /// Defaults to `print` with info/errror messages - debug messages are not outputted. Set to `nil` to disable all logging from TelemetryDeck SDK.
+    /// Defaults to `OSLog.Logger` with info/errror messages - debug messages are not outputted. Set to `nil` to disable all logging from TelemetryDeck SDK.
     ///
     /// - NOTE: If ``swiftUIPreviewMode`` is `true` (by default only when running SwiftUI previews), this value is effectively ignored, working like it's set to `nil`.
-    public var logHandler: LogHandler? = LogHandler.stdout(.info)
+    public var logHandler: LogHandler? = LogHandler.standard(.info)
 
     /// An array of signal metadata enrichers: a system for adding dynamic metadata to signals as they are recorded.
     ///

--- a/Tests/TelemetryDeckTests/LogHandlerTests.swift
+++ b/Tests/TelemetryDeckTests/LogHandlerTests.swift
@@ -6,7 +6,7 @@ final class LogHandlerTests: XCTestCase {
     var lastLevel: LogHandler.LogLevel?
 
     func testLogHandler_stdoutLogLevelDefined() {
-        XCTAssertEqual(LogHandler.stdout(.error).logLevel, .error)
+        XCTAssertEqual(LogHandler.standard(.error).logLevel, .error)
     }
     
     func testLogHandler_logLevelRespected() {


### PR DESCRIPTION
Fixes https://github.com/TelemetryDeck/SwiftSDK/issues/131. Supersedes https://github.com/TelemetryDeck/SwiftSDK/pull/150.

Before | After
-|-
<img width="507" alt="Screenshot 2024-10-31 at 16 40 21" src="https://github.com/user-attachments/assets/ea6634b8-6192-4a85-b140-1686ce33ce1b"> | <img width="429" alt="Screenshot 2024-10-31 at 16 39 41" src="https://github.com/user-attachments/assets/ed4b32fc-2012-46e5-8728-bff67dda45ac">
