### PR TITLE
Avoid checking for reserved keys in internal signals being sent

### DIFF
--- a/Sources/TelemetryDeck/Presets/TelemetryDeck+Errors.swift
+++ b/Sources/TelemetryDeck/Presets/TelemetryDeck+Errors.swift
@@ -28,7 +28,7 @@ public extension TelemetryDeck {
             errorParameters["TelemetryDeck.Error.message"] = message
         }
 
-        self.signal(
+        self.internalSignal(
             "TelemetryDeck.Error.occurred",
             parameters: errorParameters.merging(parameters) { $1 },
             floatValue: floatValue,

--- a/Sources/TelemetryDeck/Presets/TelemetryDeck+Navigation.swift
+++ b/Sources/TelemetryDeck/Presets/TelemetryDeck+Navigation.swift
@@ -23,7 +23,7 @@ extension TelemetryDeck {
     public static func navigationPathChanged(from source: String, to destination: String, customUserID: String? = nil) {
         NavigationStatus.shared.previousNavigationPath = destination
 
-        self.signal(
+        self.internalSignal(
             "TelemetryDeck.Navigation.pathChanged",
             parameters: [
                 "TelemetryDeck.Navigation.schemaVersion": "1",

--- a/Sources/TelemetryDeck/Presets/TelemetryDeck+Purchases.swift
+++ b/Sources/TelemetryDeck/Presets/TelemetryDeck+Purchases.swift
@@ -73,7 +73,7 @@ extension TelemetryDeck {
             }
         }
 
-        self.signal(
+        self.internalSignal(
             "TelemetryDeck.Purchase.completed",
             parameters: purchaseParameters.merging(parameters) { $1 },
             floatValue: priceValueInUSD,

--- a/Sources/TelemetryDeck/Signals/SignalManager.swift
+++ b/Sources/TelemetryDeck/Signals/SignalManager.swift
@@ -18,22 +18,6 @@ protocol SignalManageable {
 final class SignalManager: SignalManageable, @unchecked Sendable {
     static let minimumSecondsToPassBetweenRequests: Double = 10
 
-    static let reservedKeysLowercased: Set<String> = Set(
-        [
-            "type", "clientUser", "appID", "sessionID", "floatValue",
-            "newSessionBegan", "platform", "systemVersion", "majorSystemVersion", "majorMinorSystemVersion", "appVersion", "buildNumber",
-            "isSimulator", "isDebug", "isTestFlight", "isAppStore", "modelName", "architecture", "operatingSystem", "targetEnvironment",
-            "locale", "region", "appLanguage", "preferredLanguage", "telemetryClientVersion",
-        ].map { $0.lowercased() }
-    )
-
-    static let internalSignalNames: Set<String> = [
-        "TelemetryDeck.Error.occurred",
-        "TelemetryDeck.Navigation.pathChanged",
-        "TelemetryDeck.Purchase.completed",
-        "TelemetryDeck.Session.started",
-    ]
-
     private var signalCache: SignalCache<SignalPostBody>
     let configuration: TelemetryManagerConfiguration
 
@@ -91,33 +75,6 @@ final class SignalManager: SignalManageable, @unchecked Sendable {
         customUserID: String?,
         configuration: TelemetryManagerConfiguration
     ) {
-        // warn users about reserved keys to avoid unexpected behavior
-        if signalName.lowercased().hasPrefix("telemetrydeck."), !Self.internalSignalNames.contains(signalName) {
-            configuration.logHandler?.log(
-                .error,
-                message: "Sending signal with reserved prefix 'TelemetryDeck.' will cause unexpected behavior. Please use another prefix instead."
-            )
-        } else if Self.reservedKeysLowercased.contains(signalName.lowercased()) {
-            configuration.logHandler?.log(
-                .error,
-                message: "Sending signal with reserved name '\(signalName)' will cause unexpected behavior. Please use another name instead."
-            )
-        }
-
-        for parameterKey in parameters.keys {
-            if parameterKey.lowercased().hasPrefix("telemetrydeck.") {
-                configuration.logHandler?.log(
-                    .error,
-                    message: "Sending parameter with reserved key prefix 'TelemetryDeck.' will cause unexpected behavior. Please use another prefix instead."
-                )
-            } else if Self.reservedKeysLowercased.contains(parameterKey.lowercased()) {
-                configuration.logHandler?.log(
-                    .error,
-                    message: "Sending parameter with reserved key '\(parameterKey)' will cause unexpected behavior. Please use another key instead."
-                )
-            }
-        }
-
         // enqueue signal to sending cache
         DispatchQueue.main.async {
             let defaultUserIdentifier = self.defaultUserIdentifier

--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -70,7 +70,7 @@ public struct TelemetryManagerConfiguration: Sendable {
     public var sessionID = UUID() {
         didSet {
             if sendNewSessionBeganSignal {
-                TelemetryDeck.signal("TelemetryDeck.Session.started")
+                TelemetryDeck.internalSignal("TelemetryDeck.Session.started")
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/TelemetryDeck/SwiftSDK/issues/202.