### PR TITLE
Return to reference type for config by unchecking Sendable conformance

### DIFF
--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -17,7 +17,7 @@ let sdkVersion = "2.5.1"
 /// Use an instance of this class to specify settings for TelemetryManager. If these settings change during the course of
 /// your runtime, it might be a good idea to hold on to the instance and update it as needed. TelemetryManager's behaviour
 /// will update as well.
-public struct TelemetryManagerConfiguration: Sendable {
+public final class TelemetryManagerConfiguration: @unchecked Sendable {
     /// Your app's ID for Telemetry. Set this during initialization.
     public let telemetryAppID: String
 


### PR DESCRIPTION
I played around with different options, but all ideas I've had to resolve #192 and #201 included breaking changes that require  documentation updates and users to update their code. After thinking about it again, I believe we should simply return to a reference type and mark the configuration file as `@unchecked Sendable`. This effectively turns off the compiler check for Sendable conformance and thread-safety. I think this is fine, firstly because we have our own synchronization mechanism in `TelemetryManager` when accessing the configuration:
```swift
   var configuration: TelemetryManagerConfiguration {
        get { queue.sync(flags: .barrier) { return _configuration } }
        set { queue.sync(flags: .barrier) { _configuration = newValue } }
    }
```

Secondly, configuration changes are rare, so even if we didn't have any syncing logic, this shouldn't affect users in practical usage as concurrent changes to the configuration is unlikely to happen.