### PR TITLE
Replace 'nonisolated(unsafe)' from Swift 5.10+ with a more compatible approach

### DIFF
--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -325,8 +325,21 @@ public final class TelemetryManager: @unchecked Sendable {
         self.startSessionAndObserveAppForegrounding()
     }
 
-    nonisolated(unsafe)
-    static var initializedTelemetryManager: TelemetryManager?
+    private final class TelemetryManagerStorage: @unchecked Sendable {
+        static let shared = TelemetryManagerStorage()
+        private let queue = DispatchQueue(label: "com.telemetrydeck.TelemetryManager.static", attributes: .concurrent)
+        private var _manager: TelemetryManager?
+
+        var manager: TelemetryManager? {
+            get { queue.sync { _manager } }
+            set { queue.sync(flags: .barrier) { _manager = newValue } }
+        }
+    }
+
+    static var initializedTelemetryManager: TelemetryManager? {
+        get { TelemetryManagerStorage.shared.manager }
+        set { TelemetryManagerStorage.shared.manager = newValue }
+    }
 
     let signalManager: SignalManageable
 


### PR DESCRIPTION
This should fix #191.

While I couldn't reproduce the problem as I can't run Xcode 15.0.1 on my Mac, it makes sense they are getting this error since the `nonisolated(unsafe)` was introduces in Swift 5.10 (see [SE-412](https://github.com/swiftlang/swift-evolution/blob/e273da0a1b7414fae9aaceb439715493de54a472/proposals/0412-strict-concurrency-for-global-variables.md)). It seems to be an oversight of Apple or the Swift engineers that I can't see the build error when building a package that is using Swift 5.9 toolset in later Swift versions.