### PR TITLE
Get 'hashedDefaultUser' working even without a custom user set

### DIFF
--- a/Sources/TelemetryDeck/Signals/SignalManager.swift
+++ b/Sources/TelemetryDeck/Signals/SignalManager.swift
@@ -13,6 +13,8 @@ import TVUIKit
 protocol SignalManageable {
     func processSignal(_ signalName: String, parameters: [String: String], floatValue: Double?, customUserID: String?, configuration: TelemetryManagerConfiguration)
     func attemptToSendNextBatchOfCachedSignals()
+
+    @MainActor var defaultUserIdentifier: String { get }
 }
 
 final class SignalManager: SignalManageable, @unchecked Sendable {
@@ -237,7 +239,7 @@ private extension SignalManager {
 
 // MARK: - Helpers
 
-private extension SignalManager {
+extension SignalManager {
     #if os(macOS)
     /// A custom ``UserDefaults`` instance specific to TelemetryDeck and the current application.
     private var customDefaults: UserDefaults? {

--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -259,8 +259,9 @@ public final class TelemetryManager: @unchecked Sendable {
         TelemetryDeck.updateDefaultUserID(to: newDefaultUser)
     }
 
-    public var hashedDefaultUser: String? {
-        guard let defaultUser = configuration.defaultUser else { return nil }
+    @MainActor
+    public var hashedDefaultUser: String {
+        let defaultUser = self.signalManager.defaultUserIdentifier
         return CryptoHashing.sha256(string: defaultUser, salt: configuration.salt)
     }
 

--- a/Tests/TelemetryDeckTests/TelemetryDeckTests.swift
+++ b/Tests/TelemetryDeckTests/TelemetryDeckTests.swift
@@ -64,7 +64,7 @@ struct TelemetryDeckTests {
             }
         }
         
-        var configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
+        let configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
         configuration.metadataEnrichers.append(BasicEnricher())
         
         let signalManager = FakeSignalManager()
@@ -85,7 +85,7 @@ struct TelemetryDeckTests {
             }
         }
         
-        var configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
+        let configuration = TelemetryManagerConfiguration(appID: UUID().uuidString)
         configuration.metadataEnrichers.append(BasicEnricher())
         
         let signalManager = FakeSignalManager()
@@ -117,7 +117,7 @@ struct TelemetryDeckTests {
     func sendsSignals_withAnalyticsExplicitlyEnabled() {
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        var configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
         configuration.analyticsDisabled = false
         
         let signalManager = FakeSignalManager()
@@ -132,7 +132,7 @@ struct TelemetryDeckTests {
     func doesNotSendSignals_withAnalyticsExplicitlyDisabled() {
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        var configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
         configuration.analyticsDisabled = true
         
         let signalManager = FakeSignalManager()
@@ -149,7 +149,7 @@ struct TelemetryDeckTests {
 
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        var configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
         configuration.analyticsDisabled = false
         
         let signalManager = FakeSignalManager()
@@ -206,4 +206,6 @@ private class FakeSignalManager: @preconcurrency SignalManageable {
     }
 
     func attemptToSendNextBatchOfCachedSignals() {}
+
+    var defaultUserIdentifier: String { UUID().uuidString }
 }


### PR DESCRIPTION
This fixes #190.

But please note that this adds a `@MainActor` requirement to the `hashedDefaultUser` because accessing the `identifierForVendor` on iOS needs access to `UIDevice.current`, which is only accessible on the main thread. Technically speaking, this is a breaking change, as users who migrated to Swift 6 may no longer be able to access `hashedDefaultUser` from a background thread without adding concurrency to their code.

Having that said, since the original PR states that this field was added to report the user ID to other systems, that kind of code should be done in concurrent contexts anyways and therefore for most users the fix would be as simple as adding the `await` keyword.