### PR TITLE
Allow providing custom URLSession used internally for network requests

### DIFF
--- a/Sources/TelemetryDeck/Signals/Signal.swift
+++ b/Sources/TelemetryDeck/Signals/Signal.swift
@@ -407,7 +407,11 @@ extension DefaultSignalPayload {
         #if os(iOS) || os(tvOS)
         return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? "leftToRight" : "rightToLeft"
         #elseif os(macOS)
-        return NSApp.userInterfaceLayoutDirection == .leftToRight ? "leftToRight" : "rightToLeft"
+        if let nsApp = NSApp {
+            return nsApp.userInterfaceLayoutDirection == .leftToRight ? "leftToRight" : "rightToLeft"
+        } else {
+            return "N/A"
+        }
         #else
         return "N/A"
         #endif

--- a/Sources/TelemetryDeck/Signals/SignalManager.swift
+++ b/Sources/TelemetryDeck/Signals/SignalManager.swift
@@ -231,7 +231,7 @@ private extension SignalManager {
                 self.configuration.logHandler?.log(.debug, message: messageString)
             }
 
-            let task = URLSession.shared.dataTask(with: urlRequest, completionHandler: completionHandler)
+            let task = self.configuration.urlSession.dataTask(with: urlRequest, completionHandler: completionHandler)
             task.resume()
         }
     }

--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -75,6 +75,13 @@ public final class TelemetryManagerConfiguration: @unchecked Sendable {
         }
     }
 
+    /// A customizable `URLSession` used for network requests within TelemetryDeck.
+    ///
+    /// This property allows you to override the default `URLSession.shared` for cases where
+    /// a custom session configuration is needed (e.g., for network interception, caching strategies,
+    /// or debugging). If not set, the `URLSession.shared` instance will be used.
+    public var urlSession: URLSession = URLSession.shared
+
     @available(*, deprecated, message: "Please use the testMode property instead")
     public var sendSignalsInDebugConfiguration: Bool = false
 


### PR DESCRIPTION
Fixes https://github.com/TelemetryDeck/SwiftSDK/issues/215

Note that I also had to make a change in the logic to detect `layoutDirection` on macOS because it seems that `NSApp` is (surprisingly!) an implicitly-unwrapped Optional which caused tests to fail.