### PR TITLE
Add new option to allow other SDKs to suppress reserved key warnings

### DIFF
--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -137,6 +137,11 @@ public final class TelemetryManagerConfiguration: @unchecked Sendable {
     /// However it won't interfere with SwiftUI Previews, when explicitly settings this value to `false`.
     public var analyticsDisabled: Bool = false
 
+    /// Determines whether to log warnings when user-provided custom parameters use reserved parameter names that are internal to TelemetryDeck SDKs.
+    ///
+    /// - NOTE: Do not change this property if you're using our SDK in your app. This is for usage from other TelemetryDeck SDKs only.
+    public var reservedParameterWarningsEnabled: Bool = true
+
     /// Log the current status to the signal cache to the console.
     @available(*, deprecated, message: "Please use the logHandler property instead")
     public var showDebugLogs: Bool = false

--- a/Sources/TelemetryDeck/TelemetryDeck.swift
+++ b/Sources/TelemetryDeck/TelemetryDeck.swift
@@ -48,38 +48,40 @@ public enum TelemetryDeck {
         let combinedSignalName = (configuration.defaultSignalPrefix ?? "") + signalName
         let prefixedParameters = parameters.mapKeys { (configuration.defaultParameterPrefix ?? "") + $0 }
 
-        // warn users about reserved keys to avoid unexpected behavior
-        if combinedSignalName.lowercased().hasPrefix("telemetrydeck.") {
-            configuration.logHandler?.log(
-                .error,
-                message: "Sending signal with reserved prefix 'TelemetryDeck.' will cause unexpected behavior. Please use another prefix instead."
-            )
-        } else if Self.reservedKeysLowercased.contains(combinedSignalName.lowercased()) {
-            configuration.logHandler?.log(
-                .error,
-                message: "Sending signal with reserved name '\(combinedSignalName)' will cause unexpected behavior. Please use another name instead."
-            )
-        }
+        if configuration.reservedParameterWarningsEnabled {
+            // warn users about reserved keys to avoid unexpected behavior
+            if combinedSignalName.lowercased().hasPrefix("telemetrydeck.") {
+                configuration.logHandler?.log(
+                    .error,
+                    message: "Sending signal with reserved prefix 'TelemetryDeck.' will cause unexpected behavior. Please use another prefix instead."
+                )
+            } else if Self.reservedKeysLowercased.contains(combinedSignalName.lowercased()) {
+                configuration.logHandler?.log(
+                    .error,
+                    message: "Sending signal with reserved name '\(combinedSignalName)' will cause unexpected behavior. Please use another name instead."
+                )
+            }
 
-        // only check parameters (not default ones)
-        for parameterKey in prefixedParameters.keys {
-            if parameterKey.lowercased().hasPrefix("telemetrydeck.") {
-                configuration.logHandler?.log(
-                    .error,
-                    message: "Sending parameter with reserved key prefix 'TelemetryDeck.' will cause unexpected behavior. Please use another prefix instead."
-                )
-            } else if Self.reservedKeysLowercased.contains(parameterKey.lowercased()) {
-                configuration.logHandler?.log(
-                    .error,
-                    message: "Sending parameter with reserved key '\(parameterKey)' will cause unexpected behavior. Please use another key instead."
-                )
+            // only check parameters (not default ones)
+            for parameterKey in prefixedParameters.keys {
+                if parameterKey.lowercased().hasPrefix("telemetrydeck.") {
+                    configuration.logHandler?.log(
+                        .error,
+                        message: "Sending parameter with reserved key prefix 'TelemetryDeck.' will cause unexpected behavior. Please use another prefix instead."
+                    )
+                } else if Self.reservedKeysLowercased.contains(parameterKey.lowercased()) {
+                    configuration.logHandler?.log(
+                        .error,
+                        message: "Sending parameter with reserved key '\(parameterKey)' will cause unexpected behavior. Please use another key instead."
+                    )
+                }
             }
         }
 
         self.internalSignal(combinedSignalName, parameters: prefixedParameters, floatValue: floatValue, customUserID: customUserID)
     }
 
-    /// A signal being sent without enriching the signal name with  a prefix. Also, any reserved signal name check are skipped. Only for internal use.
+    /// A signal being sent without enriching the signal name with a prefix. Also, any reserved signal name checks are skipped. Only for internal use.
     static func internalSignal(
         _ signalName: String,
         parameters: [String: String] = [:],


### PR DESCRIPTION
Fixes https://github.com/TelemetryDeck/SwiftSDK/issues/220

@winsmith The git diff for `TelemetryClient` looks like I changed more, but I actually only added the check `if configuration.reservedParameterWarningsEnabled` and indented the rest as-is inside it's body.