### PR TITLE
Add new duration signal type where the SDK tracks duration & sends it

### DIFF
--- a/Sources/TelemetryDeck/Helpers/DurationSignalTracker.swift
+++ b/Sources/TelemetryDeck/Helpers/DurationSignalTracker.swift
@@ -1,0 +1,103 @@
+#if canImport(WatchKit)
+import WatchKit
+#elseif canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+@MainActor
+@available(watchOS 7.0, *)
+final class DurationSignalTracker {
+    static let shared = DurationSignalTracker()
+
+    private struct CachedData {
+        let startTime: Date
+        let parameters: [String: String]
+    }
+
+    private var startedSignals: [String: CachedData] = [:]
+    private var lastEnteredBackground: Date?
+
+    private init() {
+        self.setupAppLifecycleObservers()
+    }
+
+    func startTracking(_ signalName: String, parameters: [String: String]) {
+        self.startedSignals[signalName] = CachedData(startTime: Date(), parameters: parameters)
+    }
+
+    func stopTracking(_ signalName: String) -> (duration: TimeInterval, parameters: [String: String])? {
+        guard let trackingData = self.startedSignals[signalName] else { return nil }
+        self.startedSignals[signalName] = nil
+
+        let duration = Date().timeIntervalSince(trackingData.startTime)
+        return (duration, trackingData.parameters)
+    }
+
+    private func setupAppLifecycleObservers() {
+#if canImport(WatchKit)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackgroundNotification),
+            name: WKApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForegroundNotification),
+            name: WKApplication.willEnterForegroundNotification,
+            object: nil
+        )
+#elseif canImport(UIKit)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackgroundNotification),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForegroundNotification),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+#elseif canImport(AppKit)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackgroundNotification),
+            name: NSApplication.didResignActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForegroundNotification),
+            name: NSApplication.willBecomeActiveNotification,
+            object: nil
+        )
+#endif
+    }
+
+    @objc
+    private func handleDidEnterBackgroundNotification() {
+        self.lastEnteredBackground = Date()
+    }
+
+    @objc
+    private func handleWillEnterForegroundNotification() {
+        guard let lastEnteredBackground else { return }
+        let backgroundDuration = Date().timeIntervalSince(lastEnteredBackground)
+
+        for (signalName, data) in self.startedSignals {
+            self.startedSignals[signalName] = CachedData(
+                startTime: data.startTime.addingTimeInterval(backgroundDuration),
+                parameters: data.parameters
+            )
+        }
+
+        self.lastEnteredBackground = nil
+    }
+}


### PR DESCRIPTION
This implements what we had discussed in our call recently, documented in the Pirate Metrics overview task as:
> Timed Actions (naming?)
>
> Todo Cihat: SDK has convenience functions for "named screen/function/activity has started" and "named screen/function/activity has finished". This creates a signal that sends "named screen/function/activity has taken x seconds"

I'm posting this as a separate PR because while it was discussed for Pirate Metrics, it's not directly related and can be published as a separate SDK improvement. I feel it could distract/confuse people if combined with Pirate Metrics.

I decided to call the APIs `startDurationSignal` and `stopAndSendDurationSignal`. These two functions are the only added public API. The duration will be reported in the parameter `TelemetryDeck.Signal.durationInSeconds`. The SDK takes care of the duration tracking internally, including making sure the duration only reflects the app's foreground time.

Should I adjust the Swift SDK setup guide? Or write a new doc page about this? Or maybe a blog article?