### PR TITLE
Introduce automatic session tracking & enhance default parameters

### DIFF
--- a/Sources/TelemetryDeck/Helpers/DurationSignalTracker.swift
+++ b/Sources/TelemetryDeck/Helpers/DurationSignalTracker.swift
@@ -36,7 +36,7 @@ final class DurationSignalTracker {
     }
 
     private func setupAppLifecycleObservers() {
-#if canImport(WatchKit)
+        #if canImport(WatchKit)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleDidEnterBackgroundNotification),
@@ -50,7 +50,7 @@ final class DurationSignalTracker {
             name: WKApplication.willEnterForegroundNotification,
             object: nil
         )
-#elseif canImport(UIKit)
+        #elseif canImport(UIKit)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleDidEnterBackgroundNotification),
@@ -64,7 +64,7 @@ final class DurationSignalTracker {
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
-#elseif canImport(AppKit)
+        #elseif canImport(AppKit)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleDidEnterBackgroundNotification),
@@ -78,7 +78,7 @@ final class DurationSignalTracker {
             name: NSApplication.willBecomeActiveNotification,
             object: nil
         )
-#endif
+        #endif
     }
 
     @objc

--- a/Sources/TelemetryDeck/Helpers/SessionManager.swift
+++ b/Sources/TelemetryDeck/Helpers/SessionManager.swift
@@ -1,10 +1,167 @@
-import Foundation
+#if canImport(WatchKit)
+import WatchKit
+#elseif canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
-@MainActor
-final class SessionManager {
+// TODO: test logic of this class in a real-world app to find edge cases (unit tests feasible?)
+// TODO: add automatic sending of session lengths as default parameters
+// TODO: persist save dinstinct days used count separately
+// TODO: persist first install date separately
+
+final class SessionManager: @unchecked Sendable {
+    private struct StoredSession: Codable {
+        let startedAt: Date
+        let durationInSeconds: Int
+    }
+
     static let shared = SessionManager()
-    private init() {}
+    private static let sessionsKey = "sessions"
 
-    // TODO: make sure that all session start dates and their duration are persisted (use a Codable?)
-    // TODO: implement auto-detection of new install and send `newInstallDetected` with `firstSessionDate`
+    private var sessionsByID: [UUID: StoredSession]
+
+    private var currentSessionID: UUID = UUID()
+    private var currentSessionStartetAt: Date = .distantPast
+    private var currentSessionDuration: TimeInterval = .zero
+
+    private var sessionDurationUpdater: Timer?
+    private var sessionDurationLastUpdatedAt: Date?
+
+    private let persistenceQueue = DispatchQueue(label: "com.telemetrydeck.sessionmanager.persistence")
+
+    private init() {
+        if
+            let existingSessionData = TelemetryDeck.customDefaults?.data(forKey: Self.sessionsKey),
+            let existingSessions = try? JSONDecoder().decode([UUID: StoredSession].self, from: existingSessionData)
+        {
+            // upon app start, clean up any sessions older than 90 days to keep dict small
+            let cutoffDate = Date().addingTimeInterval(-(90 * 24 * 60 * 60))
+            self.sessionsByID = existingSessions.filter { $0.value.startedAt > cutoffDate }
+        } else {
+            self.sessionsByID = [:]
+        }
+
+        self.setupAppLifecycleObservers()
+    }
+
+    func startSessionTimer() {
+        // stop automatic duration counting of previous session
+        self.stopSessionTimer()
+
+        // TODO: when sessionsByID is empty here, then send "`newInstallDetected`" with `firstSessionDate`
+
+        // start a new session
+        self.currentSessionID = UUID()
+        self.currentSessionStartetAt = Date()
+        self.currentSessionDuration = .zero
+
+        // start automatic duration counting of new session
+        self.updateSessionDuration()
+        self.sessionDurationUpdater = Timer.scheduledTimer(
+            timeInterval: 1,
+            target: self,
+            selector: #selector(updateSessionDuration),
+            userInfo: nil,
+            repeats: true
+        )
+    }
+
+    private func stopSessionTimer() {
+        self.sessionDurationUpdater?.invalidate()
+        self.sessionDurationUpdater = nil
+        self.sessionDurationLastUpdatedAt = nil
+    }
+
+    @objc
+    private func updateSessionDuration() {
+        if let sessionDurationLastUpdatedAt {
+            self.currentSessionDuration += Date().timeIntervalSince(sessionDurationLastUpdatedAt)
+        }
+
+        self.sessionDurationLastUpdatedAt = Date()
+        self.persistCurrentSessionIfNeeded()
+    }
+
+    private func persistCurrentSessionIfNeeded() {
+        // Ignore sessions under 1 second
+        guard self.currentSessionDuration >= 1.0 else { return }
+
+        // Add or update the current session
+        self.sessionsByID[self.currentSessionID] = StoredSession(
+            startedAt: self.currentSessionStartetAt,
+            durationInSeconds: Int(self.currentSessionDuration)
+        )
+
+        // Save changes to UserDefaults without blocking Main thread
+        self.persistenceQueue.async {
+            guard let updatedSessionData = try? JSONEncoder().encode(self.sessionsByID) else { return }
+            TelemetryDeck.customDefaults?.set(updatedSessionData, forKey: Self.sessionsKey)
+        }
+    }
+
+    @objc
+    private func handleDidEnterBackgroundNotification() {
+        self.updateSessionDuration()
+        self.stopSessionTimer()
+    }
+
+    @objc
+    private func handleWillEnterForegroundNotification() {
+        self.updateSessionDuration()
+        self.sessionDurationUpdater = Timer.scheduledTimer(
+            timeInterval: 1,
+            target: self,
+            selector: #selector(updateSessionDuration),
+            userInfo: nil,
+            repeats: true
+        )
+    }
+
+    private func setupAppLifecycleObservers() {
+        #if canImport(WatchKit)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackgroundNotification),
+            name: WKApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForegroundNotification),
+            name: WKApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        #elseif canImport(UIKit)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackgroundNotification),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForegroundNotification),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        #elseif canImport(AppKit)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackgroundNotification),
+            name: NSApplication.didResignActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForegroundNotification),
+            name: NSApplication.willBecomeActiveNotification,
+            object: nil
+        )
+        #endif
+    }
 }

--- a/Sources/TelemetryDeck/Signals/SignalManager.swift
+++ b/Sources/TelemetryDeck/Signals/SignalManager.swift
@@ -240,14 +240,6 @@ private extension SignalManager {
 // MARK: - Helpers
 
 extension SignalManager {
-    #if os(macOS)
-    /// A custom ``UserDefaults`` instance specific to TelemetryDeck and the current application.
-    private var customDefaults: UserDefaults? {
-        let appIdHash = CryptoHashing.sha256(string: configuration.telemetryAppID, salt: "")
-        return UserDefaults(suiteName: "com.telemetrydeck.\(appIdHash.suffix(12))")
-    }
-    #endif
-
     /// The default user identifier. If the platform supports it, the ``identifierForVendor``. Otherwise, a self-generated `UUID` which is persisted in custom `UserDefaults` if available.
     @MainActor
     var defaultUserIdentifier: String {
@@ -262,11 +254,11 @@ extension SignalManager {
             return "unknown user \(DefaultSignalPayload.platform) \(DefaultSignalPayload.systemVersion) \(DefaultSignalPayload.buildNumber)"
         }
         #elseif os(macOS)
-        if let customDefaults = customDefaults, let defaultUserIdentifier = customDefaults.string(forKey: "defaultUserIdentifier") {
+        if let customDefaults = TelemetryDeck.customDefaults, let defaultUserIdentifier = customDefaults.string(forKey: "defaultUserIdentifier") {
             return defaultUserIdentifier
         } else {
             let defaultUserIdentifier = UUID().uuidString
-            customDefaults?.set(defaultUserIdentifier, forKey: "defaultUserIdentifier")
+            TelemetryDeck.customDefaults?.set(defaultUserIdentifier, forKey: "defaultUserIdentifier")
             return defaultUserIdentifier
         }
         #else

--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -69,7 +69,7 @@ public final class TelemetryManagerConfiguration: @unchecked Sendable {
     /// Beginning a new session automatically sends a "TelemetryDeck.Session.started" Signal if `sendNewSessionBeganSignal` is `true`
     public var sessionID = UUID() {
         didSet {
-            SessionManager.shared.startSession()
+            SessionManager.shared.startNewSession()
 
             if sendNewSessionBeganSignal {
                 TelemetryDeck.internalSignal("TelemetryDeck.Session.started")

--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -62,18 +62,17 @@ public final class TelemetryManagerConfiguration: @unchecked Sendable {
 
     /// A random identifier for the current user session.
     ///
-    /// On iOS, tvOS, and watchOS, the session identifier will automatically update whenever your app returns from background, or if it is
-    /// launched from cold storage. On other platforms, a new identifier will be generated each time your app launches. If you'd like
+    /// On iOS, tvOS, and watchOS, the session identifier will automatically update whenever your app returns from background after 5 minutes,
+    /// or if it is launched from cold storage. On other platforms, a new identifier will be generated each time your app launches. If you'd like
     /// more fine-grained session support, write a new random session identifier into this property each time a new session begins.
     ///
-    /// Beginning a new session automatically sends a "newSessionBegan" Signal if `sendNewSessionBeganSignal` is `true`
+    /// Beginning a new session automatically sends a "TelemetryDeck.Session.started" Signal if `sendNewSessionBeganSignal` is `true`
     public var sessionID = UUID() {
         didSet {
+            SessionManager.shared.startSession()
+
             if sendNewSessionBeganSignal {
                 TelemetryDeck.internalSignal("TelemetryDeck.Session.started")
-
-                // TODO: send `totalSessionsCount` and `distinctDaysUsed` as well as `weekday`, `dayOfMonth`, and `dayOfYear`
-                // TODO: calculate and send `averageSessionSeconds`
             }
         }
     }

--- a/Sources/TelemetryDeck/TelemetryDeck.swift
+++ b/Sources/TelemetryDeck/TelemetryDeck.swift
@@ -212,4 +212,13 @@ public enum TelemetryDeck {
     public static func generateNewSession() {
         TelemetryManager.shared.configuration.sessionID = UUID()
     }
+
+    // MARK: - Internals
+    /// A custom ``UserDefaults`` instance specific to TelemetryDeck and the current application.
+    static var customDefaults: UserDefaults? {
+        guard let configuration = TelemetryManager.initializedTelemetryManager?.configuration else { return nil }
+
+        let appIdHash = CryptoHashing.sha256(string: configuration.telemetryAppID, salt: "")
+        return UserDefaults(suiteName: "com.telemetrydeck.\(appIdHash.suffix(12))")
+    }
 }

--- a/Sources/TelemetryDeck/TelemetryDeck.swift
+++ b/Sources/TelemetryDeck/TelemetryDeck.swift
@@ -122,7 +122,7 @@ public enum TelemetryDeck {
         self.internalSignal(signalName, parameters: durationParameters.merging(parameters) { $1 })
     }
 
-    /// A signal being sent without enriching the signal name with  a prefix. Also, any reserved signal name check are skipped. Only for internal use.
+    /// A signal being sent without enriching the signal name with a prefix. Also, any reserved signal name check are skipped. Only for internal use.
     static func internalSignal(
         _ signalName: String,
         parameters: [String: String] = [:],


### PR DESCRIPTION
This implements the first 3 [Pirate Metrics](https://github.com/TelemetryDeck/SwiftSDK/pull/223) subtasks:

- [x] [SwiftSDK: Persist session data with automatic start/end/duration tracking)](https://github.com/orgs/TelemetryDeck/projects/27/views/2?pane=issue&itemId=92131022)
- [x] [SwiftSDK: Auto-detect and send new installation](https://github.com/orgs/TelemetryDeck/projects/27/views/2?pane=issue&itemId=92131049)
- [x] [SwiftSDK: Calculate and send session-related stats like average length, distinct days used etc.](https://github.com/orgs/TelemetryDeck/projects/27/views/2?pane=issue&itemId=92131242)

Note that I have expanded upon the requested `dayOfWeek`, `dayOfMonth`, and `dayOfYear` fields and ended up with the following fields (the [requirements comment](https://github.com/TelemetryDeck/web/issues/1905#issuecomment-2368911503) was updated):

  * `TelemetryDeck.Calendar.dayOfWeek` - Integer from 1 (Monday) to 7 (Sunday)
  * `TelemetryDeck.Calendar.dayOfMonth` - Integer from 1 to 31, representing the day of the month
  * `TelemetryDeck.Calendar.dayOfYear` - Integer from 1 to 366 (accounting for leap years), representing the day of the year
  * `TelemetryDeck.Calendar.weekOfYear` - Integer from 1 to 53, representing the week of the year
  * `TelemetryDeck.Calendar.monthOfYear` - Integer from 1 to 12, representing the month
  * `TelemetryDeck.Calendar.quarterOfYear` - Integer from 1 to 4, representing the quarter
  * `TelemetryDeck.Calendar.hourOfDay` - Integer from 1 to 24, representing the hour
  * `TelemetryDeck.Calendar.isWeekend` - Bool, `true` if Saturday or Sunday, `false` otherwise

All parameters use the Gregorian calendar and return -1 if the value cannot be calculated.

This PR is merge-ready as it targets the `feature/pirate-metrics` branch (which is 🚧 until all sub-tasks done).