### PR TITLE
Adds NSPrivacyAccessedAPICategoryUserDefaults to privacy manifest

### DIFF
--- a/Sources/TelemetryClient/PrivacyInfo.xcprivacy
+++ b/Sources/TelemetryClient/PrivacyInfo.xcprivacy
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+            <dict>
+                    <key>NSPrivacyAccessedAPIType</key>
+                    <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                    <key>NSPrivacyAccessedAPITypeReasons</key>
+                    <array>
+                        <string>CA92.1</string>
+                    </array>
+            </dict>
+        </array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>
@@ -28,14 +39,6 @@
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                            <string>CA92.1</string>
-                        </array>
-                </dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>

--- a/Sources/TelemetryClient/PrivacyInfo.xcprivacy
+++ b/Sources/TelemetryClient/PrivacyInfo.xcprivacy
@@ -28,6 +28,14 @@
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                            <string>CA92.1</string>
+                        </array>
+                </dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>

--- a/Sources/TelemetryDeck/PrivacyInfo.xcprivacy
+++ b/Sources/TelemetryDeck/PrivacyInfo.xcprivacy
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+            <dict>
+                    <key>NSPrivacyAccessedAPIType</key>
+                    <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                    <key>NSPrivacyAccessedAPITypeReasons</key>
+                    <array>
+                        <string>CA92.1</string>
+                    </array>
+            </dict>
+        </array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>
@@ -28,14 +39,6 @@
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                            <string>CA92.1</string>
-                        </array>
-                </dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>

--- a/Sources/TelemetryDeck/PrivacyInfo.xcprivacy
+++ b/Sources/TelemetryDeck/PrivacyInfo.xcprivacy
@@ -28,6 +28,14 @@
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                            <string>CA92.1</string>
+                        </array>
+                </dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>


### PR DESCRIPTION
Hi,

Once we updated one of our apps to the latest version of the SDK, it got rejected by App Store Review for it was missing the `NSPrivacyAccessedAPICategoryUserDefaults` entry in the privacy manifest. We tracked it down to the TelemetryDeck SDK.

This PR addresses the issue by adding the missing description to both privacy manifests. Our app was accepted using a fork of the library with this change 🤩 .

Cheers,
K

PS: perhaps a step can be added to the GitHub workflow to check that? e.g. https://github.com/crasowas/app_store_required_privacy_manifest_analyser