### PR TITLE
Fix potential URL creation issue with leading/trailing slashes

### DIFF
--- a/Sources/TelemetryDeck/Signals/SignalManager.swift
+++ b/Sources/TelemetryDeck/Signals/SignalManager.swift
@@ -262,13 +262,16 @@ extension SignalManager {
 extension SignalManager {
     private func send(_ signalPostBodies: [SignalPostBody], completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) {
         DispatchQueue.global(qos: .utility).async {
-            let subpath: String
+            let url: URL
             if let namespace = self.configuration.namespace, !namespace.isEmpty {
-                subpath = "/v2/namespace/\(namespace)/"
+                url = self.configuration.apiBaseURL
+                    .appendingPathComponent("v2")
+                    .appendingPathComponent("namespace")
+                    .appendingPathComponent(namespace)
             } else {
-                subpath = "/v2/"
+                url = self.configuration.apiBaseURL
+                    .appendingPathComponent("v2")
             }
-            let url = self.configuration.apiBaseURL.appendingPathComponent(subpath)
 
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"


### PR DESCRIPTION
A customer reported seeing URL construction errors in sandbox mode on an iOS 17 device:

```
Error Domain=NSURLErrorDomain
Code=-1000
NSLocalizedDescription=Invalid URL,
NSErrorFailingURLStringKey=https://nom.telemetrydeck.com/v2/
```

While I could not reproduce this (I tested in iOS 17 simulator) according to some research the error is potentially related to leading/trailing characters like slashes or whitespaces – so I reworked the way the URLs are constructed to avoid subpaths with slashes in them. The new approach is known to work for sure, so it might help avoid the issue in some edge cases where it potentially could fail.