### PR TITLE
feat: Update device target versions, xcode 26.1.1, switch to swift lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,43 +1,44 @@
 name: Test and Lint
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches:
-      - "*"
+    push:
+        branches: [main]
+    pull_request:
+        branches:
+            - "*"
 
 jobs:
-  lint:
-    name: Lint Code
-    runs-on: ubuntu-latest
-    steps:
-      - name: Repository checkout
-        uses: actions/checkout@v4
-      - name: Lint
-        uses: norio-nomura/action-swiftlint@3.2.1
-        with:
-          args: --strict
-  test:
-    name: Test Xcode ${{ matrix.xcode }} - ${{ matrix.xcodebuildCommand }}
-    runs-on: "macos-26"
-    strategy:
-      fail-fast: true
-      matrix:
-        xcode:
-          - "26"
-        xcodebuildCommand:
-          - "-sdk iphonesimulator -destination 'platform=iOS Simulator,OS=26.1,name=iPhone 17'"
-          - "-sdk macosx -destination 'platform=macOS'"
-          - "-sdk xrsimulator -destination 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'"
-          - "-sdk appletvsimulator -destination 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation)'"
-          - "-sdk watchsimulator -destination 'platform=watchOS Simulator,OS=26.0,name=Apple Watch Series 11 (46mm)'"
-    steps:
-      - name: Repository checkout
-        uses: actions/checkout@v4
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.xcode }}
-      - name: Build and Test
-        run: xcodebuild test -scheme TelemetryDeck-Package ${{ matrix.xcodebuildCommand }}
+    lint:
+        name: Lint Code
+        runs-on: ubuntu-latest
+        steps:
+            - name: Repository checkout
+              uses: actions/checkout@v5
+            - name: Get swift version
+              run: swift --version
+            - name: Lint
+              run: make checklint
+    test:
+        name: Test Xcode ${{ matrix.xcode }} - ${{ matrix.xcodebuildCommand }}
+        runs-on: "macos-26"
+        strategy:
+            fail-fast: true
+            matrix:
+                xcode:
+                    - "26.1.1"
+                xcodebuildCommand:
+                    - "-sdk iphonesimulator -destination 'platform=iOS Simulator,OS=26.1,name=iPhone 17'"
+                    - "-sdk macosx -destination 'platform=macOS'"
+                    - "-sdk xrsimulator -destination 'platform=visionOS Simulator,OS=26.1,name=Apple Vision Pro'"
+                    - "-sdk appletvsimulator -destination 'platform=tvOS Simulator,OS=26.1,name=Apple TV 4K (3rd generation)'"
+                    - "-sdk watchsimulator -destination 'platform=watchOS Simulator,OS=26.1,name=Apple Watch Series 11 (46mm)'"
+        steps:
+            - name: Repository checkout
+              uses: actions/checkout@v5
+            - name: Setup Xcode
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: ${{ matrix.xcode }}
+
+            - name: Build and Test
+              run: xcodebuild test -scheme TelemetryDeck-Package ${{ matrix.xcodebuildCommand }}

--- a/.github/workflows/cocoapods.yaml
+++ b/.github/workflows/cocoapods.yaml
@@ -1,30 +1,30 @@
 name: deploy_to_cocoapods
 
 on:
-  push:
-    tags:
-      - "*"
+    push:
+        tags:
+            - "*"
 
 jobs:
-  build:
-    runs-on: macos-15
+    build:
+        runs-on: macos-15
 
-    steps:
-      - uses: actions/checkout@v4
+        steps:
+            - uses: actions/checkout@v5
 
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+            - name: Setup Xcode
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: latest-stable
 
-      - name: Install Cocoapods
-        run: gem install cocoapods
+            - name: Install Cocoapods
+              run: gem install cocoapods
 
-      - name: Deploy to Cocoapods
-        run: |
-          set -eo pipefail
-          export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
-          pod lib lint --allow-warnings
-          pod trunk push --allow-warnings
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+            - name: Deploy to Cocoapods
+              run: |
+                  set -eo pipefail
+                  export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+                  pod lib lint --allow-warnings
+                  pod trunk push --allow-warnings
+              env:
+                  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: help test build checklint lint
+
+help:
+	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+test: ## Run unit tests
+	@swift test
+
+build: ## Build the library
+	@swift build
+
+checklint: ## Checks the project for linting errors, used by the CI
+	@swift format lint --strict --configuration ./.swift-format -r .
+
+lint: ## Applies all auto-correctable lint issues and reformats all source files
+	@swift format --configuration ./.swift-format -r -i .


### PR DESCRIPTION
This PR makes the following changes to the CI flow:

- We're now targeting Xcode 26.1
- Simulator devices used for testing running 26.1
- Switched to Swift's built-in format / lint tool (note: the lint task will be failing for a while until all lints are addressed)
- Added a Makefile with quick `make test`, `make lint`, `make build` and other commands.