### PR TITLE
fix: tag-release script

### DIFF
--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -10,7 +10,7 @@ import Foundation
     import TVUIKit
 #endif
 
-let sdkVersion = "2.10.0"
+let sdkVersion = "2.11.0"
 
 /// Configuration for TelemetryManager
 ///

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -12,10 +12,10 @@ fi
 version=$1
 
 # Replace version String in TelemetryClient.swift with specified version
-sed -i '' "s/\"SwiftClient .*\"/\"SwiftClient $version\"/g" Sources/TelemetryClient/TelemetryClient.swift
+sed -i '' "s/\"SwiftClient .*\"/\"SwiftClient $version\"/g" Sources/TelemetryDeck/TelemetryClient.swift
 
 # Make a commit & tag it
-git add Sources/TelemetryClient/TelemetryClient.swift
+git add Sources/TelemetryDeck/TelemetryClient.swift
 git commit -m "Bump Version to $version"
 git tag $version $(git rev-parse HEAD)
 

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -12,7 +12,7 @@ fi
 version=$1
 
 # Replace version String in TelemetryClient.swift with specified version
-sed -i '' "s/\"SwiftClient .*\"/\"SwiftClient $version\"/g" Sources/TelemetryDeck/TelemetryClient.swift
+sed -i '' "s/let sdkVersion = \".*\"/let sdkVersion = \"$version\"/" Sources/TelemetryDeck/TelemetryClient.swift
 
 # Make a commit & tag it
 git add Sources/TelemetryDeck/TelemetryClient.swift


### PR DESCRIPTION
This PR fixes the tag-release.sh script to correctly update the SDK version and create a git tag