### PR TITLE
Fix running many session duration timers at once

### DIFF
--- a/Sources/TelemetryDeck/Helpers/SessionManager.swift
+++ b/Sources/TelemetryDeck/Helpers/SessionManager.swift
@@ -44,6 +44,8 @@ final class SessionManager: @unchecked Sendable {
         return encoder
     }()
 
+    private var appIsInForeground = true
+
     private var recentSessions: [StoredSession]
 
     private var deletedSessionsCount: Int {
@@ -132,6 +134,9 @@ final class SessionManager: @unchecked Sendable {
     }
 
     func startNewSession() {
+        // Prevent incorrectly starting new session (and persistence timer) if in background
+        guard appIsInForeground else { return }
+
         // stop automatic duration counting of previous session
         self.stopSessionTimer()
 
@@ -201,12 +206,14 @@ final class SessionManager: @unchecked Sendable {
 
     @objc
     private func handleDidEnterBackgroundNotification() {
+        appIsInForeground = false
         self.updateSessionDuration()
         self.stopSessionTimer()
     }
 
     @objc
     private func handleWillEnterForegroundNotification() {
+        appIsInForeground = true
         self.updateSessionDuration()
         self.sessionDurationUpdater = Timer.scheduledTimer(
             timeInterval: 1,

--- a/Sources/TelemetryDeck/Helpers/SessionManager.swift
+++ b/Sources/TelemetryDeck/Helpers/SessionManager.swift
@@ -160,7 +160,7 @@ final class SessionManager: @unchecked Sendable {
         // start automatic duration counting of new session
         self.updateSessionDuration()
         self.sessionDurationUpdater = Timer.scheduledTimer(
-            timeInterval: 1,
+            timeInterval: 5,
             target: self,
             selector: #selector(updateSessionDuration),
             userInfo: nil,
@@ -216,7 +216,7 @@ final class SessionManager: @unchecked Sendable {
         appIsInForeground = true
         self.updateSessionDuration()
         self.sessionDurationUpdater = Timer.scheduledTimer(
-            timeInterval: 1,
+            timeInterval: 5,
             target: self,
             selector: #selector(updateSessionDuration),
             userInfo: nil,


### PR DESCRIPTION
# Bug

If user code changes the SDK configuration while the app is in the background, then the SDK can create a `SessionManager.updateSessionDuration()` timer that it never invalidates. After a while, these runaway timers add up, and can trigger many times a second, consuming problematic amounts of CPU power.

When I first noticed this behavior, it was causing Retcon.app to use 15-25% CPU while in the background, as it was trying to persist 2,834 sessions, extremely frequently.

# Fix

This commit adds a check for foreground state before creating the timer.

# Cause

Changing SDK configuration (by calling `TelemetryDeck.initialize()`), or even just by setting a new value on `TelemetryManagerConfiguration.sessionID`, causes TelemetryDeck to create a new session update timer, regardless of foreground state. This is a problem, because the SDK only invalidates the session update timer when going back _to_ a background state. As such, the reference to the timer created in the background is silently replaced when creating a new timer, instead of first invalidating the former timer.

Calling `TelemetryDeck.initialize()` actually causes the timer to be created after a fixed 0.5s delay, making the bug very likely to occur if a macOS app updates its TelemetryDeck configuration upon being focused.

The following code reliably triggers the issue, if the user switches to the app, then quickly switches away:
```swift
NotificationCenter.default.addObserver(forName: NSApplication.didBecomeActiveNotification, object: nil, queue: nil) { _ in
	someExistingTelemetryDeckConfiguration.sessionID = UUID() // reset sessionID when entering foreground
	TelemetryDeck.initialize(config: someExistingTelemetryDeckConfiguration)
}
```
