### PR TITLE
fix: don't auto-emit `Session.started` on background-only cold launches

### DIFF
--- a/Sources/TelemetryDeck/TelemetryClient.swift
+++ b/Sources/TelemetryDeck/TelemetryClient.swift
@@ -64,6 +64,9 @@ public final class TelemetryManagerConfiguration: @unchecked Sendable {
     /// Defaults to true. Set to false to prevent automatically sending this signal.
     public var sendNewSessionBeganSignal: Bool = true
 
+    /// If `true` the TelemetryDeck SDK will count system-scheduled background launches as user sesssions.
+    public var registerBackgroundSessions: Bool = false
+
     /// A random identifier for the current user session.
     ///
     /// On iOS, tvOS, and watchOS, the session identifier will automatically update whenever your app returns from background after 5 minutes,
@@ -438,6 +441,18 @@ public final class TelemetryManager: @unchecked Sendable {
     private func startSessionAndObserveAppForegrounding() {
         // initially start a new session upon app start (delayed so that `didSet` triggers)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            #if os(iOS) || os(tvOS)
+            // Skip the initial session for pure background cold launches (Background app refresh,
+            // HealthKit background delivery, content-available push, etc.) unless the consumer
+            // has opted into `registerBackgroundSessions`. The `willEnterForeground`
+            // observer registered below still handles the case where the user later opens
+            // the app from this background-launched process.
+            guard TelemetryManager.shared.configuration.registerBackgroundSessions
+                || TelemetryEnvironment.isAppExtension
+                || UIApplication.shared.applicationState != .background else {
+                return
+            }
+            #endif
             TelemetryDeck.generateNewSession()
         }
 


### PR DESCRIPTION
# Fix https://github.com/TelemetryDeck/SwiftSDK/issues/281: don't auto-emit `Session.started` on background-only cold launches

## Summary
With `Config.sendNewSessionBeganSignal` set to `true`, `TelemetryDeck.Session.started` fires on every process launch, including background-only cold launches triggered by `BGAppRefreshTask`, `HKObserverQuery` background delivery, content-available push notifications, significant-location-change wakes, etc.

The SDK does not distinguish a user-initiated foreground launch from a system-scheduled background launch that the user never sees. As a result, session counts on the TelemetryDeck dashboard are inflated by launches the user never initiated, and any metric derived from sessions (shares-per-session, screens-per-session, average session duration, retention) is skewed.

## Fix
Add a new configuration property to explicitly enable background sessions, which are discounted by default:
```Swift
public final class TelemetryManagerConfiguration: @unchecked Sendable {
...
    /// If `true` the TelemetryDeck SDK will count system-scheduled background launches as user sesssions.
    public var registerBackgroundSessions: Bool = false
...
}    
```
and then check that flag in `startSessionAndObserveAppForegrounding()`.