### PR TITLE
Introduce cache cap, backoff when retrying previously failed events 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,22 +24,17 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                xcode:
-                    - 26.4.1
                 xcodebuildCommand:
-                    - "test -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=26.4.1,name=iPhone 17'"
-                    - "test -sdk macosx -destination 'platform=macOS'"
-                    - "test -sdk xrsimulator -destination 'platform=visionOS Simulator,OS=26.4.1,name=Apple Vision Pro'"
-                    - "test -sdk appletvsimulator -destination 'platform=tvOS Simulator,OS=26.4,name=Apple TV 4K (3rd generation)'"
-                    - "test -sdk watchsimulator -destination 'platform=watchOS Simulator,OS=26.4,name=Apple Watch Series 11 (46mm)'"
+                    - "-sdk iphonesimulator -destination 'platform=iOS Simulator,OS=26.5,name=iPhone 17'"
+                    - "-sdk macosx -destination 'platform=macOS'"
+                    - "-sdk xrsimulator -destination 'platform=visionOS Simulator,OS=26.5,name=Apple Vision Pro'"
+                    - "-sdk appletvsimulator -destination 'platform=tvOS Simulator,OS=26.5,name=Apple TV 4K (3rd generation)'"
+                    - "-sdk watchsimulator -destination 'platform=watchOS Simulator,OS=26.5,name=Apple Watch Series 11 (46mm)'"
                     - "build -destination 'platform=macOS,variant=Mac Catalyst'"
         steps:
             - name: Repository checkout
-              uses: actions/checkout@v5
-            - name: Setup Xcode
-              uses: maxim-lobanov/setup-xcode@v1
-              with:
-                  xcode-version: ${{ matrix.xcode }}
-
+              uses: actions/checkout@v6
+            - name: Select Xcode version
+              run: sudo xcode-select -s '/Applications/Xcode_26.5.0.app/Contents/Developer'
             - name: Build and Test
-              run: xcodebuild -scheme TelemetryDeck ${{ matrix.xcodebuildCommand }}
+              run: xcodebuild test -scheme TelemetryDeck-Package ${{ matrix.xcodebuildCommand }}

--- a/README.md
+++ b/README.md
@@ -304,6 +304,27 @@ try await TelemetryDeck.initialize(
 )
 ```
 
+### Cache configuration
+
+`DefaultEventCache` and `DefaultEventTransmitter` expose parameters to control how the SDK will retry sending events in case of a problem:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `DefaultEventCache(cacheLimit:)` | `Int` | `10_000` | Maximum events held in memory; oldest events are dropped first when the limit is reached |
+| `DefaultEventTransmitter(transmitInterval:)` | `TimeInterval` | `10` | Seconds between transmission attempts |
+| `DefaultEventTransmitter(maxBackoffInterval:)` | `TimeInterval` | `300` | Upper bound for exponential backoff after consecutive failed batches |
+
+```swift
+let cache = DefaultEventCache(cacheLimit: 5_000)
+let transmitter = DefaultEventTransmitter(
+    configuration: config,
+    cache: cache,
+    logger: DefaultLogger(),
+    transmitInterval: 30,
+    maxBackoffInterval: 600
+)
+```
+
 You can also implement the `EventTransmitting` protocol for a fully custom transport layer.
 
 ### Custom Logging

--- a/Sources/TelemetryDeck/Transport/DefaultEventCache.swift
+++ b/Sources/TelemetryDeck/Transport/DefaultEventCache.swift
@@ -5,20 +5,29 @@ public actor DefaultEventCache: EventCaching {
     private var events: [Event] = []
     private let maxBatchSize = 100
     private let fileURL: URL
+    private let cacheLimit: Int
 
     /// Creates a cache that stores events in the default caches directory.
-    public init() {
+    public init(cacheLimit: Int = 10_000) {
+        assert(cacheLimit > 0, "cacheLimit must be greater than zero")
         let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         self.fileURL = cachesURL.appendingPathComponent("telemetrysignalcache.json")
+        self.cacheLimit = cacheLimit
     }
 
     /// Creates a cache that stores events at the given file URL.
-    public init(fileURL: URL) {
+    public init(fileURL: URL, cacheLimit: Int = 10_000) {
+        assert(cacheLimit > 0, "cacheLimit must be greater than zero")
         self.fileURL = fileURL
+        self.cacheLimit = cacheLimit
     }
 
-    /// Appends an event to the in-memory store.
+    /// Appends an event to the in-memory store, evicting the oldest events when the cache limit is reached.
     public func add(_ event: Event) {
+        if events.count >= cacheLimit {
+            let overflow = events.count - cacheLimit + 1
+            events.removeFirst(overflow)
+        }
         events.append(event)
     }
 
@@ -41,11 +50,21 @@ public actor DefaultEventCache: EventCaching {
     }
 
     /// Reads previously persisted events from disk and prepends them to the in-memory queue.
+    ///
+    /// Loaded events are older than in-memory events and occupy the front of the queue under FIFO.
+    /// If the combined count exceeds `cacheLimit`, the oldest loaded events are trimmed first.
     public func restore() async {
         guard let data = try? Data(contentsOf: fileURL),
             let loaded = try? JSONDecoder.telemetryDecoder.decode([Event].self, from: data)
         else { return }
         try? FileManager.default.removeItem(at: fileURL)
-        events = loaded + events
+        let combined = loaded.count + events.count
+        if combined > cacheLimit {
+            let excess = combined - cacheLimit
+            let trimmedLoaded = Array(loaded.dropFirst(min(excess, loaded.count)))
+            events = trimmedLoaded + events
+        } else {
+            events = loaded + events
+        }
     }
 }

--- a/Sources/TelemetryDeck/Transport/DefaultEventTransmitter.swift
+++ b/Sources/TelemetryDeck/Transport/DefaultEventTransmitter.swift
@@ -85,12 +85,17 @@ public actor DefaultEventTransmitter: EventTransmitting {
                 logger.log(.error, "Transmit failed: response was not HTTP, retrying \(events.count) events")
                 return events
             }
-            guard (200...299).contains(http.statusCode) else {
+            switch http.disposition {
+            case .success:
+                logger.log(.debug, "Transmitted \(events.count) events (HTTP \(http.statusCode))")
+                return []
+            case .drop(let reason):
+                logger.log(.error, "Dropping \(events.count) events: rejected by server — \(reason)")
+                return []
+            case .retry:
                 logger.log(.error, "Transmit failed with HTTP \(http.statusCode), retrying \(events.count) events")
                 return events
             }
-            logger.log(.debug, "Transmitted \(events.count) events (HTTP \(http.statusCode))")
-            return []
         } catch {
             logger.log(.error, "Transmit failed: \(error.localizedDescription), retrying \(events.count) events")
             return events
@@ -139,5 +144,30 @@ public actor DefaultEventTransmitter: EventTransmitting {
         let url = URL(string: base + "v2/namespace/\(configuration.namespace)/")
         assert(url != nil, "Failed to construct service URL from base: \(configuration.apiBaseURL)")
         return url
+    }
+}
+
+private enum ResponseDisposition {
+    case success
+    case drop(reason: String)
+    case retry
+}
+
+extension HTTPURLResponse {
+    fileprivate var disposition: ResponseDisposition {
+        if (200...299).contains(statusCode) {
+            return .success
+        }
+        switch statusCode {
+        case 400: return .drop(reason: "Bad Request (400)")
+        case 401: return .drop(reason: "Unauthorized (401)")
+        case 403: return .drop(reason: "Forbidden (403)")
+        case 404: return .drop(reason: "Not Found (404)")
+        case 413: return .drop(reason: "Payload Too Large (413)")
+        case 422: return .drop(reason: "Unprocessable Entity (422)")
+        case 501: return .drop(reason: "Not Implemented (501)")
+        case 505: return .drop(reason: "HTTP Version Not Supported (505)")
+        default: return .retry
+        }
     }
 }

--- a/Sources/TelemetryDeck/Transport/DefaultEventTransmitter.swift
+++ b/Sources/TelemetryDeck/Transport/DefaultEventTransmitter.swift
@@ -7,28 +7,43 @@ public actor DefaultEventTransmitter: EventTransmitting {
     private let logger: any Logging
     private let httpClient: any HTTPDataLoader
     private var transmitTask: Task<Void, Never>?
-    private let transmitInterval: TimeInterval = 10
+    private let transmitInterval: TimeInterval
+    private let maxBackoffInterval: TimeInterval
+    private var consecutiveFailures: Int = 0
 
     /// Creates a transmitter with the given configuration, cache, logger, and URL session.
     public init(
         configuration: TelemetryDeck.Config,
         cache: any EventCaching,
         logger: any Logging,
-        urlSession: URLSession = .shared
+        urlSession: URLSession = .shared,
+        transmitInterval: TimeInterval = 10,
+        maxBackoffInterval: TimeInterval = 300
     ) {
-        self.init(configuration: configuration, cache: cache, logger: logger, httpClient: urlSession)
+        self.init(
+            configuration: configuration,
+            cache: cache,
+            logger: logger,
+            httpClient: urlSession,
+            transmitInterval: transmitInterval,
+            maxBackoffInterval: maxBackoffInterval
+        )
     }
 
     init(
         configuration: TelemetryDeck.Config,
         cache: any EventCaching,
         logger: any Logging,
-        httpClient: any HTTPDataLoader
+        httpClient: any HTTPDataLoader,
+        transmitInterval: TimeInterval = 10,
+        maxBackoffInterval: TimeInterval = 300
     ) {
         self.configuration = configuration
         self.cache = cache
         self.logger = logger
         self.httpClient = httpClient
+        self.transmitInterval = transmitInterval
+        self.maxBackoffInterval = maxBackoffInterval
     }
 
     /// Starts the repeating transmission timer.
@@ -37,7 +52,7 @@ public actor DefaultEventTransmitter: EventTransmitting {
         transmitTask = Task { [weak self] in
             while !Task.isCancelled {
                 await self?.transmitBatch()
-                let interval = self?.transmitInterval ?? 10
+                let interval = await self?.nextInterval() ?? 10
                 try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
             }
         }
@@ -82,8 +97,9 @@ public actor DefaultEventTransmitter: EventTransmitting {
         }
     }
 
-    /// Immediately transmits all cached events without waiting for the next timer tick.
+    /// Immediately transmits all cached events without waiting for the next timer tick, resets the backoff counter to 0 before transmitting.
     public func flush() async {
+        consecutiveFailures = 0
         await transmitBatch()
     }
 
@@ -93,9 +109,26 @@ public actor DefaultEventTransmitter: EventTransmitting {
         let remainingCount = await cache.count()
         logger.log(.info, "Sending \(events.count) events, \(remainingCount) remain in cache")
         let failed = await transmit(events)
-        for event in failed {
-            await cache.add(event)
+        if failed.isEmpty {
+            consecutiveFailures = 0
+        } else {
+            consecutiveFailures += 1
+            for event in failed {
+                await cache.add(event)
+            }
         }
+    }
+
+    /// Returns the current consecutive failure count, used by tests to verify backoff state.
+    func currentBackoffFailures() -> Int {
+        consecutiveFailures
+    }
+
+    private func nextInterval() -> TimeInterval {
+        guard consecutiveFailures > 0 else { return transmitInterval }
+        // Clamp the exponent to 16 to guard against overflow in pow()
+        let multiplier = pow(2.0, Double(min(consecutiveFailures, 16)))
+        return min(transmitInterval * multiplier, maxBackoffInterval)
     }
 
     private var serviceURL: URL? {

--- a/Sources/TelemetryDeck/Transport/InMemoryEventCache.swift
+++ b/Sources/TelemetryDeck/Transport/InMemoryEventCache.swift
@@ -3,12 +3,20 @@ import Foundation
 /// A non-persistent event cache that stores events only in memory; suitable for testing.
 public actor InMemoryEventCache: EventCaching {
     private var events: [Event] = []
+    private let cacheLimit: Int
 
-    /// Creates an empty in-memory event cache.
-    public init() {}
+    /// Creates an empty in-memory event cache with an optional FIFO cap.
+    public init(cacheLimit: Int = .max) {
+        assert(cacheLimit > 0, "cacheLimit must be greater than zero")
+        self.cacheLimit = cacheLimit
+    }
 
-    /// Appends an event to the in-memory store.
+    /// Appends an event to the in-memory store, evicting the oldest events when the cache limit is reached.
     public func add(_ event: Event) {
+        if events.count >= cacheLimit {
+            let overflow = events.count - cacheLimit + 1
+            events.removeFirst(overflow)
+        }
         events.append(event)
     }
 

--- a/Tests/TelemetryDeckTests/DefaultEventTransmitterTests.swift
+++ b/Tests/TelemetryDeckTests/DefaultEventTransmitterTests.swift
@@ -304,6 +304,91 @@ struct DefaultEventTransmitterTests {
     }
 
     @Test
+    func consecutiveFailuresIncrementOnFailedBatch() async {
+        let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
+        let cache = InMemoryEventCache()
+        let stub = StubHTTPClient(statusCode: 500, url: URL(string: "https://nom.telemetrydeck.com")!)
+
+        let transmitter = DefaultEventTransmitter(
+            configuration: config,
+            cache: cache,
+            logger: DefaultLogger(),
+            httpClient: stub
+        )
+
+        // Each flush() resets consecutiveFailures before transmitting, so a single failed flush leaves it at 1.
+        await cache.add(createTestEvent())
+        await transmitter.flush()
+
+        let failuresAfterOne = await transmitter.currentBackoffFailures()
+        #expect(failuresAfterOne == 1)
+
+        // The re-queued failed event is still in the cache; flush resets then the batch fails again → 1.
+        await transmitter.flush()
+
+        let failuresAfterTwo = await transmitter.currentBackoffFailures()
+        #expect(failuresAfterTwo == 1)
+    }
+
+    @Test
+    func consecutiveFailuresResetOnSuccess() async {
+        let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
+        let cache = InMemoryEventCache()
+        let switchableStub = SwitchableHTTPClient(initialStatusCode: 500, url: URL(string: "https://nom.telemetrydeck.com")!)
+
+        let transmitter = DefaultEventTransmitter(
+            configuration: config,
+            cache: cache,
+            logger: DefaultLogger(),
+            httpClient: switchableStub
+        )
+
+        // Flush with failure: reset to 0, then fail → 1.
+        await cache.add(createTestEvent())
+        await transmitter.flush()
+
+        let failuresBefore = await transmitter.currentBackoffFailures()
+        #expect(failuresBefore == 1)
+
+        // Switch to success: flush resets to 0, then batch succeeds → stays 0.
+        switchableStub.statusCode = 200
+        await transmitter.flush()
+
+        let failuresAfter = await transmitter.currentBackoffFailures()
+        #expect(failuresAfter == 0)
+    }
+
+    @Test
+    func flushResetsConsecutiveFailures() async {
+        let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
+        let cache = InMemoryEventCache()
+        let failingStub = StubHTTPClient(statusCode: 503, url: URL(string: "https://nom.telemetrydeck.com")!)
+
+        let transmitter = DefaultEventTransmitter(
+            configuration: config,
+            cache: cache,
+            logger: DefaultLogger(),
+            httpClient: failingStub
+        )
+
+        // Flush with failure leaves consecutiveFailures at 1.
+        await cache.add(createTestEvent())
+        await transmitter.flush()
+
+        let failuresBefore = await transmitter.currentBackoffFailures()
+        #expect(failuresBefore == 1)
+
+        // Flush with an empty cache: the reset fires, transmitBatch exits early (no events),
+        // so consecutiveFailures ends at 0.
+        _ = await cache.pop()
+
+        await transmitter.flush()
+
+        let failuresAfter = await transmitter.currentBackoffFailures()
+        #expect(failuresAfter == 0)
+    }
+
+    @Test
     func flushWithEmptyCacheDoesNothing() async {
         let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
         let cache = InMemoryEventCache()
@@ -357,6 +442,28 @@ private final class StubHTTPClient: HTTPDataLoader, @unchecked Sendable {
         lock.withLock { _lastRequest = request }
         onRequest?()
         return try result.get()
+    }
+}
+
+private final class SwitchableHTTPClient: HTTPDataLoader, @unchecked Sendable {
+    private let url: URL
+    private let lock = NSLock()
+    private var _statusCode: Int
+
+    var statusCode: Int {
+        get { lock.withLock { _statusCode } }
+        set { lock.withLock { _statusCode = newValue } }
+    }
+
+    init(initialStatusCode: Int, url: URL) {
+        self._statusCode = initialStatusCode
+        self.url = url
+    }
+
+    func data(for _: URLRequest) async throws -> (Data, URLResponse) {
+        let code = statusCode
+        let response = HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil)!
+        return (Data(), response)
     }
 }
 

--- a/Tests/TelemetryDeckTests/DefaultEventTransmitterTests.swift
+++ b/Tests/TelemetryDeckTests/DefaultEventTransmitterTests.swift
@@ -181,11 +181,11 @@ struct DefaultEventTransmitterTests {
         #expect(failed[1].type == "event.two")
     }
 
-    @Test
-    func transmitReturnsOriginalEventsOn400BadRequest() async {
+    @Test(arguments: [400, 401, 403, 404, 413, 422, 501, 505])
+    func transmitDropsEventsForNonRetryableStatusCode(statusCode: Int) async {
         let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
         let cache = InMemoryEventCache()
-        let stub = StubHTTPClient(statusCode: 400, url: URL(string: "https://nom.telemetrydeck.com")!)
+        let stub = StubHTTPClient(statusCode: statusCode, url: URL(string: "https://nom.telemetrydeck.com")!)
 
         let transmitter = DefaultEventTransmitter(
             configuration: config,
@@ -197,7 +197,75 @@ struct DefaultEventTransmitterTests {
         let events = [createTestEvent()]
         let failed = await transmitter.transmit(events)
 
-        #expect(failed.count == events.count)
+        #expect(failed.isEmpty, "Status \(statusCode) should drop events, not retry")
+    }
+
+    @Test(arguments: [408, 429, 500, 502, 503, 504])
+    func transmitRetriesEventsForRetryableStatusCode(statusCode: Int) async {
+        let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
+        let cache = InMemoryEventCache()
+        let stub = StubHTTPClient(statusCode: statusCode, url: URL(string: "https://nom.telemetrydeck.com")!)
+
+        let transmitter = DefaultEventTransmitter(
+            configuration: config,
+            cache: cache,
+            logger: DefaultLogger(),
+            httpClient: stub
+        )
+
+        let events = [createTestEvent()]
+        let failed = await transmitter.transmit(events)
+
+        #expect(failed.count == events.count, "Status \(statusCode) should retry events")
+    }
+
+    @Test
+    func dropStatusCodeResetsBackoffCounter() async {
+        let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
+        let cache = InMemoryEventCache()
+        let switchableStub = SwitchableHTTPClient(initialStatusCode: 500, url: URL(string: "https://nom.telemetrydeck.com")!)
+
+        let transmitter = DefaultEventTransmitter(
+            configuration: config,
+            cache: cache,
+            logger: DefaultLogger(),
+            httpClient: switchableStub
+        )
+
+        await cache.add(createTestEvent())
+        await transmitter.flush()
+        let failuresAfterRetry = await transmitter.currentBackoffFailures()
+        #expect(failuresAfterRetry == 1)
+
+        switchableStub.statusCode = 403
+        await transmitter.flush()
+        let failuresAfterDrop = await transmitter.currentBackoffFailures()
+        #expect(failuresAfterDrop == 0)
+
+        let remaining = await cache.count()
+        #expect(remaining == 0)
+    }
+
+    @Test
+    func flushDropsEventsOnNonRetryableStatus() async {
+        let config = TelemetryDeck.Config(appID: "test-app", namespace: "test")
+        let cache = InMemoryEventCache()
+        let stub = StubHTTPClient(statusCode: 401, url: URL(string: "https://nom.telemetrydeck.com")!)
+
+        let transmitter = DefaultEventTransmitter(
+            configuration: config,
+            cache: cache,
+            logger: DefaultLogger(),
+            httpClient: stub
+        )
+
+        await cache.add(createTestEvent(type: "event.one"))
+        await cache.add(createTestEvent(type: "event.two"))
+
+        await transmitter.flush()
+
+        let countAfter = await cache.count()
+        #expect(countAfter == 0)
     }
 
     @Test

--- a/Tests/TelemetryDeckTests/EventCacheTests.swift
+++ b/Tests/TelemetryDeckTests/EventCacheTests.swift
@@ -195,6 +195,60 @@ struct EventCacheTests {
         #expect(popped[1].type == "Signal.B")
     }
 
+    @Test
+    func defaultCacheLimitEvictsOldestEventsOnOverflow() async {
+        let cache = DefaultEventCache(cacheLimit: 5)
+
+        for i in 0..<7 {
+            await cache.add(createTestEvent(type: "Signal.\(i)"))
+        }
+
+        let count = await cache.count()
+        #expect(count == 5)
+
+        let popped = await cache.pop()
+        #expect(popped[0].type == "Signal.2")
+        #expect(popped[4].type == "Signal.6")
+    }
+
+    @Test
+    func restoreWithCapTrimsOldestPersistedEvents() async {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("test-restore-cap-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let writerCache = DefaultEventCache(fileURL: fileURL)
+        for i in 0..<10 {
+            await writerCache.add(createTestEvent(type: "Signal.\(i)"))
+        }
+        await writerCache.persist()
+
+        let cache = DefaultEventCache(fileURL: fileURL, cacheLimit: 5)
+        await cache.restore()
+
+        let count = await cache.count()
+        #expect(count == 5)
+
+        let popped = await cache.pop()
+        #expect(popped[0].type == "Signal.5")
+        #expect(popped[4].type == "Signal.9")
+    }
+
+    @Test
+    func inMemoryCacheLimitEvictsOldestEvents() async {
+        let cache = InMemoryEventCache(cacheLimit: 3)
+
+        for i in 0..<5 {
+            await cache.add(createTestEvent(type: "Signal.\(i)"))
+        }
+
+        let count = await cache.count()
+        #expect(count == 3)
+
+        let popped = await cache.pop()
+        #expect(popped[0].type == "Signal.2")
+        #expect(popped[2].type == "Signal.4")
+    }
+
     private func createTestEvent(type: String = "Test.signal") -> Event {
         Event(
             appID: "test-app",


### PR DESCRIPTION
This PR addresses a gap identified in #284 by capping the maximum number of events we keep in cache and introducing a back-off retry mechanism for previously failed events. 

Users can configure both by overriding initialiser parameters on `DefaultEventCache` and `DefaultEventTransmitter`:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `DefaultEventCache(cacheLimit:)` | `Int` | `10_000` | Maximum events held in memory (FIFO) |
| `DefaultEventTransmitter(transmitInterval:)` | `TimeInterval` | `10` | Seconds between transmission attempts |
| `DefaultEventTransmitter(maxBackoffInterval:)` | `TimeInterval` | `300` | Upper bound for exponential backoff after consecutive failed batches |

```swift
let cache = DefaultEventCache(cacheLimit: 5_000)
let transmitter = DefaultEventTransmitter(
    configuration: config,
    cache: cache,
    logger: DefaultLogger(),
    transmitInterval: 30,
    maxBackoffInterval: 600
)
```

If the SDK gets one of the following response codes when transmitting events, it will not attempt to send these events again (they will be permanently dropped): 400, 401, 403, 404, 413, 422, 501, 505.

Users can fully replace this implementation by providing their own `EventCaching` and `EventTransmitting` implementation