### PR TITLE
[v3] In Memory Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,22 @@ try await TelemetryDeck.initialize(
 )
 ```
 
+### In-memory-only mode (no local storage)
+
+For situations where writing to disk is undesirable (sandboxed processes, privacy-sensitive deployments, etc), pass `inMemoryOnly: true` to the convenience initializer:
+
+```swift
+try await TelemetryDeck.initialize(
+    appID: "<YOUR-APP-ID>",
+    namespace: "<YOUR-NAMESPACE>",
+    inMemoryOnly: true
+)
+```
+
+This tells the SDK to turn off features that require persistent storage and switches to in-memory operation only. For example, this activates `InMemoryEventCache` and `InMemoryProcessorStorage`.
+
+Features that become unavailable in this mode include: new-install detection and retention metrics (distinct days used, average session length, etc.). We are also unable to cache events for later transmission - any unsent events are discarded when the app is terminated.
+
 ### Cache configuration
 
 `DefaultEventCache` and `DefaultEventTransmitter` expose parameters to control how the SDK will retry sending events in case of a problem:

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ try await TelemetryDeck.initialize(
 
 This tells the SDK to turn off features that require persistent storage and switches to in-memory operation only. For example, this activates `InMemoryEventCache` and `InMemoryProcessorStorage`.
 
-Features that become unavailable in this mode include: new-install detection and retention metrics (distinct days used, average session length, etc.). We are also unable to cache events for later transmission - any unsent events are discarded when the app is terminated.
+Features that become unavailable in this mode include: new-install detection and retention metrics (distinct days used, average session length, etc.). We are also unable to cache events for later transmission - any unsent events are discarded when the app is terminated. Duration signals are also not persisted across launches - a duration started in one app launch cannot be resumed or stopped in a later one.
 
 ### Cache configuration
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 Privacy-first analytics for Apple platforms. Send events to [TelemetryDeck](https://telemetrydeck.com) from your Swift code.
 
+* [Requirements](#requirements)
+* [Installation](#installation)
+* [Quick Start](#quick-start)
+* [Sending Events](#sending-events)
+    * [Parameters](#parameters)
+    * [Float Values](#float-values)
+* [User Identifiers](#user-identifiers)
+* [Sessions](#sessions)
+* [Test Mode](#test-mode)
+* [Disabling Analytics](#disabling-analytics)
+* [Shutting Down](#shutting-down)
+* [Presets](#presets)
+    * [Navigation Tracking](#navigation-tracking)
+    * [Error Reporting](#error-reporting)
+    * [Duration Tracking](#duration-tracking)
+    * [Purchase Tracking](#purchase-tracking)
+    * [Pirate Metrics (AARRR)](#pirate-metrics-aarrr)
+* [Advanced](#advanced)
+    * [Custom Salt](#custom-salt)
+    * [Custom Server](#custom-server)
+    * [Custom Event Transmitter](#custom-event-transmitter)
+    * [In-memory-only mode (no local storage)](#in-memory-only-mode-no-local-storage)
+    * [Cache configuration](#cache-configuration)
+    * [Custom Logging](#custom-logging)
+    * [Default Event Processors](#default-event-processors)
+    * [Custom Event Processors](#custom-event-processors)
+    * [Default Parameters and Prefixes](#default-parameters-and-prefixes)
+* [Migrating from v2](#migrating-from-v2)
+    * [Breaking Changes](#breaking-changes)
+    * [Before and After](#before-and-after)
+    * [Step-by-Step Migration](#step-by-step-migration)
+* [Developing this SDK](#developing-this-sdk)
+
 ## Requirements
 
 - iOS 15+ / macOS 12+ / watchOS 8+ / tvOS 15+ / visionOS 1+
@@ -135,7 +168,7 @@ Pass `nil` to revert to the default identifier.
 
 ## Sessions
 
-A session ID is automatically generated at initialization. On iOS, tvOS, and watchOS, the session updates whenever your app returns from the background. On other platforms, a new session starts each time the app launches.
+A session ID is automatically generated at initialization. On Apple platforms with an app lifecycle (iOS, tvOS, watchOS, visionOS, and macOS), the session updates whenever your app returns from the background. On platforms without an app lifecycle, such as Linux and other server-side Swift environments, a new session starts each time the app launches.
 
 For manual session control:
 
@@ -330,7 +363,7 @@ Features that become unavailable in this mode include: new-install detection and
 
 ### Cache configuration
 
-`DefaultEventCache` and `DefaultEventTransmitter` expose parameters to control how the SDK will retry sending events in case of a problem:
+`DefaultEventCache` and `DefaultEventTransmitter` expose parameters to control how many events are buffered in memory and how the SDK retries sending events in case of a problem:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -380,7 +413,8 @@ Events pass through a pipeline of `EventProcessor` middleware before transmissio
 | 9 | `AppInfoProcessor` | Adds app version, build number, and SDK version |
 | 10 | `LocaleProcessor` | Adds locale, language, and region |
 | 11 | `CalendarProcessor` | Adds calendar context (day of week, hour, month, quarter, etc.) |
-| 12 | `AccessibilityProcessor` | Adds accessibility settings (bold text, reduce motion, etc.) and screen metrics |
+| 12 | `AccessibilityProcessor` | Adds accessibility settings (bold text, reduce motion, etc.) |
+| 13 | `DisplayProcessor` | Adds screen resolution, size, and multi-display metadata |
 
 To exclude a specific processor, remove it from the default list before initializing:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,7 +32,7 @@ gh release create 3.0.0 --generate-notes
 A beta can be cut from a branch instead of `main`. Run the script on that branch with a pre-release version, push the tag, then mark the GitHub Release as a pre-release:
 
 ```bash
-./tag-release.sh 3.0.0-beta.2
+./tag-release.sh 3.0.1
 git push --follow-tags
-gh release create 3.0.0-beta.2 --prerelease --target feat/processors --generate-notes
+gh release create 3.0.1 --prerelease --target feat/processors --generate-notes
 ```

--- a/Sources/TelemetryDeck/Capabilities/SessionManaging.swift
+++ b/Sources/TelemetryDeck/Capabilities/SessionManaging.swift
@@ -5,3 +5,8 @@ public protocol SessionManaging: EventProcessor {
     func currentSessionID() async -> UUID
     func startNewSession() async -> UUID
 }
+
+/// Shared constants for session lifecycle behaviour.
+enum SessionConstants {
+    static let backgroundThreshold: TimeInterval = 5 * 60
+}

--- a/Sources/TelemetryDeck/Processors/AppInfoProcessor.swift
+++ b/Sources/TelemetryDeck/Processors/AppInfoProcessor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let sdkVersion = "3.0.0-beta.2"
+let sdkVersion = "3.0.1"
 
 /// Enriches events with app version, build number, and SDK version metadata.
 public struct AppInfoProcessor: EventProcessor {

--- a/Sources/TelemetryDeck/Processors/InMemorySessionProcessor.swift
+++ b/Sources/TelemetryDeck/Processors/InMemorySessionProcessor.swift
@@ -44,18 +44,10 @@ public actor InMemorySessionProcessor: EventProcessor, SessionManaging {
     public func start(storage: any ProcessorStorage, logger: any Logging, emitter: any EventSending) async {
         self.emitter = emitter
 
-        lifecycleTask = Task {
-            for await event in LifecycleNotifier.events() {
-                switch event {
-                case .background:
-                    handleBackground()
-                case .foreground:
-                    await handleForeground()
-                case .termination:
-                    break
-                }
-            }
-        }
+        lifecycleTask = LifecycleSubscription.start(
+            onBackground: { await self.handleBackground() },
+            onForeground: { await self.handleForeground() }
+        )
 
         if sendSessionStartedEvent {
             await emitSessionStarted()

--- a/Sources/TelemetryDeck/Processors/InMemorySessionProcessor.swift
+++ b/Sources/TelemetryDeck/Processors/InMemorySessionProcessor.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// A session processor that keeps state entirely in memory.
+///
+public actor InMemorySessionProcessor: EventProcessor, SessionManaging {
+    private let sendSessionStartedEvent: Bool
+    private let dateProvider: DateProvider
+
+    private var currentSession: UUID
+    private var backgroundDate: Date?
+    private var lifecycleTask: Task<Void, Never>?
+    private var emitter: (any EventSending)?
+
+    /// Creates a session processor that keeps state in memory only.
+    public init(sendSessionStartedEvent: Bool = true) {
+        self.sendSessionStartedEvent = sendSessionStartedEvent
+        self.dateProvider = .system
+        self.currentSession = UUID()
+    }
+
+    init(sendSessionStartedEvent: Bool = true, dateProvider: DateProvider) {
+        self.sendSessionStartedEvent = sendSessionStartedEvent
+        self.dateProvider = dateProvider
+        self.currentSession = UUID()
+    }
+
+    /// Returns the identifier of the current session.
+    public func currentSessionID() async -> UUID {
+        currentSession
+    }
+
+    /// Generates a new session identifier and emits a session-started event if configured.
+    @discardableResult
+    public func startNewSession() async -> UUID {
+        let newID = UUID()
+        currentSession = newID
+        if sendSessionStartedEvent {
+            await emitSessionStarted()
+        }
+        return newID
+    }
+
+    /// Subscribes to app lifecycle events and emits a session-started event if configured.
+    public func start(storage: any ProcessorStorage, logger: any Logging, emitter: any EventSending) async {
+        self.emitter = emitter
+
+        lifecycleTask = Task {
+            for await event in LifecycleNotifier.events() {
+                switch event {
+                case .background:
+                    handleBackground()
+                case .foreground:
+                    await handleForeground()
+                case .termination:
+                    break
+                }
+            }
+        }
+
+        if sendSessionStartedEvent {
+            await emitSessionStarted()
+        }
+    }
+
+    /// Cancels the lifecycle subscription and releases the event emitter reference.
+    public func stop() async {
+        lifecycleTask?.cancel()
+        lifecycleTask = nil
+        emitter = nil
+    }
+
+    /// Attaches the current session identifier to the event context.
+    public func process(
+        _ input: EventInput,
+        context: EventContext,
+        next: @Sendable (EventInput, EventContext) async throws -> Event
+    ) async throws -> Event {
+        var context = context
+        context.sessionID = currentSession
+        return try await next(input, context)
+    }
+
+    func handleBackground() {
+        backgroundDate = dateProvider.now()
+    }
+
+    func handleForeground() async {
+        guard let bgDate = backgroundDate,
+            dateProvider.now().timeIntervalSince(bgDate) > SessionConstants.backgroundThreshold
+        else {
+            backgroundDate = nil
+            return
+        }
+        backgroundDate = nil
+        currentSession = UUID()
+        if sendSessionStartedEvent {
+            await emitSessionStarted()
+        }
+    }
+
+    private func emitSessionStarted() async {
+        await emitter?.send(EventInput(DefaultEvents.Session.started.rawValue, skipsReservedPrefixValidation: true))
+    }
+}

--- a/Sources/TelemetryDeck/Processors/SessionTrackingProcessor.swift
+++ b/Sources/TelemetryDeck/Processors/SessionTrackingProcessor.swift
@@ -12,8 +12,6 @@ public actor SessionTrackingProcessor: EventProcessor, SessionManaging {
         }
     }
 
-    private static let backgroundThreshold: TimeInterval = 5 * 60
-
     private let sendSessionStartedEvent: Bool
     private let dateProvider: DateProvider
 
@@ -234,7 +232,7 @@ public actor SessionTrackingProcessor: EventProcessor, SessionManaging {
 
     func handleForeground() async {
         let didRotate: Bool
-        if let bgDate = backgroundDate, dateProvider.now().timeIntervalSince(bgDate) > Self.backgroundThreshold {
+        if let bgDate = backgroundDate, dateProvider.now().timeIntervalSince(bgDate) > SessionConstants.backgroundThreshold {
             backgroundDate = nil
             if var lastSession = recentSessions.last, currentSessionAccumulatedSeconds > 0 {
                 lastSession.durationInSeconds = currentSessionAccumulatedSeconds

--- a/Sources/TelemetryDeck/Processors/SessionTrackingProcessor.swift
+++ b/Sources/TelemetryDeck/Processors/SessionTrackingProcessor.swift
@@ -96,18 +96,10 @@ public actor SessionTrackingProcessor: EventProcessor, SessionManaging {
             isNewInstall = true
         }
 
-        lifecycleTask = Task {
-            for await event in LifecycleNotifier.events() {
-                switch event {
-                case .background:
-                    handleBackground()
-                case .foreground:
-                    await handleForeground()
-                case .termination:
-                    break
-                }
-            }
-        }
+        lifecycleTask = LifecycleSubscription.start(
+            onBackground: { await self.handleBackground() },
+            onForeground: { await self.handleForeground() }
+        )
 
         recordSessionStart()
 

--- a/Sources/TelemetryDeck/Storage/InMemoryProcessorStorage.swift
+++ b/Sources/TelemetryDeck/Storage/InMemoryProcessorStorage.swift
@@ -8,51 +8,51 @@ public actor InMemoryProcessorStorage: ProcessorStorage {
     public init() {}
 
     /// Returns the data stored for the given key, or `nil` if absent.
-    public func data(forKey key: String) async -> Data? {
+    public func data(forKey key: String) -> Data? {
         store[key] as? Data
     }
 
     /// Stores or removes data for the given key.
-    public func set(_ data: Data?, forKey key: String) async {
+    public func set(_ data: Data?, forKey key: String) {
         store[key] = data
     }
 
     /// Returns the string stored for the given key, or `nil` if absent.
-    public func string(forKey key: String) async -> String? {
+    public func string(forKey key: String) -> String? {
         store[key] as? String
     }
 
     /// Stores or removes a string for the given key.
-    public func set(_ value: String?, forKey key: String) async {
+    public func set(_ value: String?, forKey key: String) {
         store[key] = value
     }
 
     /// Returns the integer stored for the given key, or `0` if absent.
-    public func integer(forKey key: String) async -> Int {
+    public func integer(forKey key: String) -> Int {
         store[key] as? Int ?? 0
     }
 
     /// Stores an integer for the given key.
-    public func set(_ value: Int, forKey key: String) async {
+    public func set(_ value: Int, forKey key: String) {
         store[key] = value
     }
 
     /// Returns the boolean stored for the given key, or `false` if absent.
-    public func bool(forKey key: String) async -> Bool {
+    public func bool(forKey key: String) -> Bool {
         store[key] as? Bool ?? false
     }
 
     /// Stores a boolean for the given key.
-    public func set(_ value: Bool, forKey key: String) async {
+    public func set(_ value: Bool, forKey key: String) {
         store[key] = value
     }
 
     /// Returns the string array stored for the given key, or `nil` if absent.
-    public func stringArray(forKey key: String) async -> [String]? {
+    public func stringArray(forKey key: String) -> [String]? {
         store[key] as? [String]
     }
 
-    func setStringArray(_ value: [String], forKey key: String) async {
+    func setStringArray(_ value: [String], forKey key: String) {
         store[key] = value
     }
 }

--- a/Sources/TelemetryDeck/Storage/InMemoryProcessorStorage.swift
+++ b/Sources/TelemetryDeck/Storage/InMemoryProcessorStorage.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// A `ProcessorStorage` implementation backed by an in-memory dictionary.
+public actor InMemoryProcessorStorage: ProcessorStorage {
+    private var store: [String: Any] = [:]
+
+    /// Creates an empty in-memory storage instance.
+    public init() {}
+
+    /// Returns the data stored for the given key, or `nil` if absent.
+    public func data(forKey key: String) async -> Data? {
+        store[key] as? Data
+    }
+
+    /// Stores or removes data for the given key.
+    public func set(_ data: Data?, forKey key: String) async {
+        store[key] = data
+    }
+
+    /// Returns the string stored for the given key, or `nil` if absent.
+    public func string(forKey key: String) async -> String? {
+        store[key] as? String
+    }
+
+    /// Stores or removes a string for the given key.
+    public func set(_ value: String?, forKey key: String) async {
+        store[key] = value
+    }
+
+    /// Returns the integer stored for the given key, or `0` if absent.
+    public func integer(forKey key: String) async -> Int {
+        store[key] as? Int ?? 0
+    }
+
+    /// Stores an integer for the given key.
+    public func set(_ value: Int, forKey key: String) async {
+        store[key] = value
+    }
+
+    /// Returns the boolean stored for the given key, or `false` if absent.
+    public func bool(forKey key: String) async -> Bool {
+        store[key] as? Bool ?? false
+    }
+
+    /// Stores a boolean for the given key.
+    public func set(_ value: Bool, forKey key: String) async {
+        store[key] = value
+    }
+
+    /// Returns the string array stored for the given key, or `nil` if absent.
+    public func stringArray(forKey key: String) async -> [String]? {
+        store[key] as? [String]
+    }
+
+    func setStringArray(_ value: [String], forKey key: String) async {
+        store[key] = value
+    }
+}

--- a/Sources/TelemetryDeck/TelemetryDeck.swift
+++ b/Sources/TelemetryDeck/TelemetryDeck.swift
@@ -60,7 +60,7 @@ public enum TelemetryDeck {
         )
     }
 
-    /// Returns the default event processors for in-memory-only mode
+    /// Returns the default event processors for in-memory-only mode.
     public static func defaultInMemoryProcessors(
         defaultUser: String? = nil,
         testMode: Bool? = nil,

--- a/Sources/TelemetryDeck/TelemetryDeck.swift
+++ b/Sources/TelemetryDeck/TelemetryDeck.swift
@@ -50,14 +50,51 @@ public enum TelemetryDeck {
         sendSessionStartedEvent: Bool = true,
         defaultParameters: EventParameters = [:]
     ) -> [any EventProcessor] {
-        let processors: [any EventProcessor] = [
+        buildProcessorList(
+            sessionProcessor: SessionTrackingProcessor(sendSessionStartedEvent: sendSessionStartedEvent),
+            defaultUser: defaultUser,
+            testMode: testMode,
+            eventPrefix: eventPrefix,
+            parameterPrefix: parameterPrefix,
+            defaultParameters: defaultParameters
+        )
+    }
+
+    /// Returns the default event processors for in-memory-only mode
+    public static func defaultInMemoryProcessors(
+        defaultUser: String? = nil,
+        testMode: Bool? = nil,
+        eventPrefix: String? = nil,
+        parameterPrefix: String? = nil,
+        sendSessionStartedEvent: Bool = true,
+        defaultParameters: EventParameters = [:]
+    ) -> [any EventProcessor] {
+        buildProcessorList(
+            sessionProcessor: InMemorySessionProcessor(sendSessionStartedEvent: sendSessionStartedEvent),
+            defaultUser: defaultUser,
+            testMode: testMode,
+            eventPrefix: eventPrefix,
+            parameterPrefix: parameterPrefix,
+            defaultParameters: defaultParameters
+        )
+    }
+
+    private static func buildProcessorList(
+        sessionProcessor: any EventProcessor,
+        defaultUser: String?,
+        testMode: Bool?,
+        eventPrefix: String?,
+        parameterPrefix: String?,
+        defaultParameters: EventParameters
+    ) -> [any EventProcessor] {
+        [
             PreviewFilterProcessor(),
             DefaultParametersProcessor(parameters: defaultParameters),
             DefaultPrefixProcessor(eventPrefix: eventPrefix, parameterPrefix: parameterPrefix),
             ValidationProcessor(),
             TestModeProcessor(override: testMode),
             UserIdentifierProcessor(defaultUser: defaultUser),
-            SessionTrackingProcessor(sendSessionStartedEvent: sendSessionStartedEvent),
+            sessionProcessor,
             DeviceProcessor(),
             AppInfoProcessor(),
             LocaleProcessor(),
@@ -65,10 +102,11 @@ public enum TelemetryDeck {
             AccessibilityProcessor(),
             DisplayProcessor(),
         ]
-        return processors
     }
 
     /// Initialises the SDK with the given app identity and processor-level options.
+    ///
+    /// When `inMemoryOnly` is `true`, the SDK uses in-memory storage only. Features that require persistent storage are disabled.
     public static func initialize(
         appID: String,
         namespace: String,
@@ -78,20 +116,37 @@ public enum TelemetryDeck {
         eventPrefix: String? = nil,
         parameterPrefix: String? = nil,
         sendSessionStartedEvent: Bool = true,
-        defaultParameters: EventParameters = [:]
+        defaultParameters: EventParameters = [:],
+        inMemoryOnly: Bool = false
     ) async throws(TelemetryDeckError) {
         let configuration = Config(appID: appID, namespace: namespace, salt: salt)
-        try await initialize(
-            configuration: configuration,
-            processors: defaultProcessors(
-                defaultUser: defaultUser,
-                testMode: testMode,
-                eventPrefix: eventPrefix,
-                parameterPrefix: parameterPrefix,
-                sendSessionStartedEvent: sendSessionStartedEvent,
-                defaultParameters: defaultParameters
+        if inMemoryOnly {
+            try await initialize(
+                configuration: configuration,
+                processors: defaultInMemoryProcessors(
+                    defaultUser: defaultUser,
+                    testMode: testMode,
+                    eventPrefix: eventPrefix,
+                    parameterPrefix: parameterPrefix,
+                    sendSessionStartedEvent: sendSessionStartedEvent,
+                    defaultParameters: defaultParameters
+                ),
+                cache: InMemoryEventCache(),
+                storage: InMemoryProcessorStorage()
             )
-        )
+        } else {
+            try await initialize(
+                configuration: configuration,
+                processors: defaultProcessors(
+                    defaultUser: defaultUser,
+                    testMode: testMode,
+                    eventPrefix: eventPrefix,
+                    parameterPrefix: parameterPrefix,
+                    sendSessionStartedEvent: sendSessionStartedEvent,
+                    defaultParameters: defaultParameters
+                )
+            )
+        }
     }
 
     /// Initialises the SDK with the given configuration, optionally overriding processors and dependencies.

--- a/Sources/TelemetryDeck/Transport/DurationTracker.swift
+++ b/Sources/TelemetryDeck/Transport/DurationTracker.swift
@@ -22,18 +22,10 @@ actor DurationTracker: DurationTracking {
     func start(storage: any ProcessorStorage) async {
         self.storage = storage
         await restoreState()
-        lifecycleTask = Task {
-            for await event in LifecycleNotifier.events() {
-                switch event {
-                case .background:
-                    handleBackground()
-                case .foreground:
-                    handleForeground()
-                case .termination:
-                    break
-                }
-            }
-        }
+        lifecycleTask = LifecycleSubscription.start(
+            onBackground: { await self.handleBackground() },
+            onForeground: { await self.handleForeground() }
+        )
     }
 
     func stop() async {

--- a/Sources/TelemetryDeck/Transport/InMemoryEventCache.swift
+++ b/Sources/TelemetryDeck/Transport/InMemoryEventCache.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A non-persistent event cache that stores events only in memory; suitable for testing.
+/// A non-persistent event cache that stores events only in memory; suitable for in-memory-only production use and testing.
 public actor InMemoryEventCache: EventCaching {
     private var events: [Event] = []
     private let cacheLimit: Int

--- a/Sources/TelemetryDeck/Transport/InMemoryEventCache.swift
+++ b/Sources/TelemetryDeck/Transport/InMemoryEventCache.swift
@@ -3,6 +3,7 @@ import Foundation
 /// A non-persistent event cache that stores events only in memory; suitable for in-memory-only production use and testing.
 public actor InMemoryEventCache: EventCaching {
     private var events: [Event] = []
+    private let maxBatchSize = 100
     private let cacheLimit: Int
 
     /// Creates an empty in-memory event cache with an optional FIFO cap.
@@ -20,11 +21,11 @@ public actor InMemoryEventCache: EventCaching {
         events.append(event)
     }
 
-    /// Removes and returns all cached events.
+    /// Removes and returns up to `maxBatchSize` events from the front of the queue.
     public func pop() -> [Event] {
-        let all = events
-        events.removeAll()
-        return all
+        let batch = Array(events.prefix(maxBatchSize))
+        events.removeFirst(min(maxBatchSize, events.count))
+        return batch
     }
 
     /// Returns the number of events currently in the cache.

--- a/Sources/TelemetryDeck/Transport/TelemetryEngine.swift
+++ b/Sources/TelemetryDeck/Transport/TelemetryEngine.swift
@@ -198,17 +198,10 @@ actor TelemetryEngine: EventSending {
     }
 
     private func setupLifecycleObservers() {
-        lifecycleTask = Task {
-            for await event in LifecycleNotifier.events() {
-                switch event {
-                case .background:
-                    await handleBackground()
-                case .foreground:
-                    await handleForeground()
-                case .termination:
-                    await handleTermination()
-                }
-            }
-        }
+        lifecycleTask = LifecycleSubscription.start(
+            onBackground: { await self.handleBackground() },
+            onForeground: { await self.handleForeground() },
+            onTermination: { await self.handleTermination() }
+        )
     }
 }

--- a/Sources/TelemetryDeck/Utilities/LifecycleSubscription.swift
+++ b/Sources/TelemetryDeck/Utilities/LifecycleSubscription.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Subscribes to app lifecycle events and forwards background, foreground, and termination transitions to the given handlers.
+enum LifecycleSubscription {
+    static func start(
+        onBackground: @escaping @Sendable () async -> Void,
+        onForeground: @escaping @Sendable () async -> Void,
+        onTermination: (@Sendable () async -> Void)? = nil
+    ) -> Task<Void, Never> {
+        Task {
+            for await event in LifecycleNotifier.events() {
+                switch event {
+                case .background:
+                    await onBackground()
+                case .foreground:
+                    await onForeground()
+                case .termination:
+                    await onTermination?()
+                }
+            }
+        }
+    }
+}

--- a/Tests/TelemetryDeckTests/EventCacheTests.swift
+++ b/Tests/TelemetryDeckTests/EventCacheTests.swift
@@ -56,17 +56,23 @@ struct EventCacheTests {
     }
 
     @Test
-    func inMemoryCacheReturnsAllEventsInOnePop() async {
+    func inMemoryCachePopReturnsBatchesUpToLimit() async {
         let cache = InMemoryEventCache()
         for _ in 0..<150 {
             await cache.add(createTestEvent())
         }
 
-        let all = await cache.pop()
-        #expect(all.count == 150)
+        let batch1 = await cache.pop()
+        #expect(batch1.count == 100)
 
-        let afterCount = await cache.count()
-        #expect(afterCount == 0)
+        let remainingCount = await cache.count()
+        #expect(remainingCount == 50)
+
+        let batch2 = await cache.pop()
+        #expect(batch2.count == 50)
+
+        let finalCount = await cache.count()
+        #expect(finalCount == 0)
     }
 
     @Test

--- a/Tests/TelemetryDeckTests/InMemoryModeTests.swift
+++ b/Tests/TelemetryDeckTests/InMemoryModeTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Testing
+
+@testable import TelemetryDeck
+
+@Suite
+struct InMemoryProcessorStorageTests {
+    @Test
+    func returnsDefaultsForUnsetKeys() async {
+        let storage = InMemoryProcessorStorage()
+        await #expect(storage.data(forKey: "x") == nil)
+        await #expect(storage.string(forKey: "x") == nil)
+        await #expect(storage.integer(forKey: "x") == 0)
+        await #expect(storage.bool(forKey: "x") == false)
+        await #expect(storage.stringArray(forKey: "x") == nil)
+    }
+
+    @Test
+    func roundTripsData() async {
+        let storage = InMemoryProcessorStorage()
+        let value = "hello".data(using: .utf8)!
+        await storage.set(value, forKey: "d")
+        await #expect(storage.data(forKey: "d") == value)
+    }
+
+    @Test
+    func roundTripsString() async {
+        let storage = InMemoryProcessorStorage()
+        await storage.set("world", forKey: "s")
+        await #expect(storage.string(forKey: "s") == "world")
+    }
+
+    @Test
+    func roundTripsInt() async {
+        let storage = InMemoryProcessorStorage()
+        await storage.set(42, forKey: "i")
+        await #expect(storage.integer(forKey: "i") == 42)
+    }
+
+    @Test
+    func roundTripsBool() async {
+        let storage = InMemoryProcessorStorage()
+        await storage.set(true, forKey: "b")
+        await #expect(storage.bool(forKey: "b") == true)
+    }
+}
+
+@Suite
+struct InMemorySessionProcessorTests {
+    private let testConfig = TelemetryDeck.Config(appID: "test-app", namespace: "test-ns")
+
+    @Test
+    func processedEventCarriesSessionID() async throws {
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: false)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: MockEventSender())
+
+        let pipeline = ProcessorPipeline(
+            processors: [processor],
+            finalizer: EventFinalizer(configuration: testConfig)
+        )
+
+        let event = try await pipeline.process(EventInput("Test.event"), context: EventContext())
+        #expect(event.sessionID != nil)
+
+        await processor.stop()
+    }
+
+    @Test
+    func sessionStartedIsEmittedWhenEnabled() async throws {
+        let emitter = CapturingEventSender()
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: true)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: emitter)
+
+        let sentNames = await emitter.sentEvents.map(\.name)
+        #expect(sentNames.contains(DefaultEvents.Session.started.rawValue))
+
+        await processor.stop()
+    }
+
+    @Test
+    func sessionStartedIsNotEmittedWhenDisabled() async throws {
+        let emitter = CapturingEventSender()
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: false)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: emitter)
+
+        let sentNames = await emitter.sentEvents.map(\.name)
+        #expect(!sentNames.contains(DefaultEvents.Session.started.rawValue))
+
+        await processor.stop()
+    }
+
+    @Test
+    func newInstallDetectedIsAbsent() async throws {
+        let emitter = CapturingEventSender()
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: true)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: emitter)
+
+        let sentNames = await emitter.sentEvents.map(\.name)
+        #expect(!sentNames.contains(DefaultEvents.Acquisition.newInstallDetected.rawValue))
+
+        await processor.stop()
+    }
+
+    @Test
+    func noRetentionOrAcquisitionParametersOnEvents() async throws {
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: false)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: MockEventSender())
+
+        let pipeline = ProcessorPipeline(
+            processors: [processor],
+            finalizer: EventFinalizer(configuration: testConfig)
+        )
+
+        let event = try await pipeline.process(EventInput("Test.event"), context: EventContext())
+
+        let retentionKeys = [
+            DefaultParams.Retention.totalSessionsCount.rawValue,
+            DefaultParams.Retention.distinctDaysUsed.rawValue,
+            DefaultParams.Retention.distinctDaysUsedLastMonth.rawValue,
+            DefaultParams.Retention.averageSessionSeconds.rawValue,
+            DefaultParams.Retention.previousSessionSeconds.rawValue,
+        ]
+        for key in retentionKeys {
+            #expect(event.payload[key] == nil, "Expected no \(key) in event payload")
+        }
+
+        #expect(event.payload[DefaultParams.Acquisition.firstSessionDate.rawValue] == nil)
+        #expect(event.payload[DefaultParams.Acquisition.isNewInstall.rawValue] == nil)
+
+        await processor.stop()
+    }
+
+    @Test
+    func shortBackgroundKeepsSameSession() async throws {
+        let clock = MutableClock()
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: false, dateProvider: clock.dateProvider)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: MockEventSender())
+
+        let sessionBefore = await processor.currentSessionID()
+
+        await processor.handleBackground()
+        clock.advance(by: 60)
+        await processor.handleForeground()
+
+        let sessionAfter = await processor.currentSessionID()
+        #expect(sessionBefore == sessionAfter)
+
+        await processor.stop()
+    }
+
+    @Test
+    func longBackgroundRotatesSession() async throws {
+        let clock = MutableClock()
+        let processor = InMemorySessionProcessor(sendSessionStartedEvent: false, dateProvider: clock.dateProvider)
+        await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: MockEventSender())
+
+        let sessionBefore = await processor.currentSessionID()
+
+        await processor.handleBackground()
+        clock.advance(by: 360)
+        await processor.handleForeground()
+
+        let sessionAfter = await processor.currentSessionID()
+        #expect(sessionBefore != sessionAfter)
+
+        await processor.stop()
+    }
+}
+
+@Suite
+struct InMemoryModeNoDiskWriteTests {
+    @Test
+    func engineWithInMemoryStorageDoesNotWriteToUserDefaults() async throws {
+        let appID = "td-in-memory-no-disk-test"
+        let appIdHash = CryptoHashing.sha256(string: appID, salt: "")
+        let suiteName = "com.telemetrydeck.\(appIdHash.suffix(12))"
+
+        UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+
+        let config = TelemetryDeck.Config(appID: appID, namespace: "test")
+        let engine = await TelemetryEngine.create(
+            configuration: config,
+            processors: [InMemorySessionProcessor()],
+            cache: InMemoryEventCache(),
+            transmitter: SpyEventTransmitter(),
+            storage: InMemoryProcessorStorage()
+        )
+        await engine.send(EventInput("Test.inMemory"))
+        await engine.shutdown()
+
+        let defaults = UserDefaults(suiteName: suiteName)
+        let sdkKeys = ["recentSessions", "deletedSessionsCount", "firstSessionDate", "distinctDaysUsed", "installID", "durationTrackerState"]
+        for key in sdkKeys {
+            #expect(defaults?.object(forKey: key) == nil, "Expected no \(key) in UserDefaults suite after in-memory operation")
+        }
+
+        UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+    }
+}

--- a/Tests/TelemetryDeckTests/TestSupport.swift
+++ b/Tests/TelemetryDeckTests/TestSupport.swift
@@ -2,50 +2,6 @@ import Foundation
 
 @testable import TelemetryDeck
 
-actor InMemoryProcessorStorage: ProcessorStorage {
-    private var storage: [String: Any] = [:]
-
-    func data(forKey key: String) async -> Data? {
-        storage[key] as? Data
-    }
-
-    func set(_ value: Data?, forKey key: String) async {
-        storage[key] = value
-    }
-
-    func string(forKey key: String) async -> String? {
-        storage[key] as? String
-    }
-
-    func set(_ value: String?, forKey key: String) async {
-        storage[key] = value
-    }
-
-    func integer(forKey key: String) async -> Int {
-        storage[key] as? Int ?? 0
-    }
-
-    func set(_ value: Int, forKey key: String) async {
-        storage[key] = value
-    }
-
-    func bool(forKey key: String) async -> Bool {
-        storage[key] as? Bool ?? false
-    }
-
-    func set(_ value: Bool, forKey key: String) async {
-        storage[key] = value
-    }
-
-    func stringArray(forKey key: String) async -> [String]? {
-        storage[key] as? [String]
-    }
-
-    func setStringArray(_ value: [String], forKey key: String) async {
-        storage[key] = value
-    }
-}
-
 struct NoOpLogger: Logging {
     func log(_ level: LogLevel, _ message: @autoclosure () -> String) {}
 }


### PR DESCRIPTION
This PR formalises in-memory mode of operation for the SDK. In this mode, none of our default processors will use client side persistence to disk. 

```swift
try await TelemetryDeck.initialize(
    appID: "<YOUR-APP-ID>",
    namespace: "<YOUR-NAMESPACE>",
    inMemoryOnly: true
)
```


Features unavailable in in-memory only mode:

- Persistent event caching: events that haven't been sent will be discarded when the app terminates.
- New-install detection
- Session retention metrics
- Cross-launch duration persistence: duration events are usable only during the lifetime of the app.
