### PR TITLE
fix: stop SessionManager racing (and copying) recentSessions on the main thread

### DIFF
--- a/Sources/TelemetryDeck/Helpers/SessionManager.swift
+++ b/Sources/TelemetryDeck/Helpers/SessionManager.swift
@@ -44,7 +44,21 @@ final class SessionManager: @unchecked Sendable {
         return encoder
     }()
 
-    private var recentSessions: [StoredSession]
+    /// Guards ``unsafeRecentSessions``.
+    ///
+    /// Only ever held around the array access itself, never while encoding or writing to
+    /// `UserDefaults`, so a reader can never end up waiting behind that I/O.
+    private let sessionsLock = NSLock()
+
+    /// Only ever touched while holding ``sessionsLock``. Read it through ``recentSessions``.
+    private var unsafeRecentSessions: [StoredSession]
+
+    /// A snapshot of the recorded sessions, safe to read from any thread.
+    private var recentSessions: [StoredSession] {
+        self.sessionsLock.lock()
+        defer { self.sessionsLock.unlock() }
+        return self.unsafeRecentSessions
+    }
 
     private var deletedSessionsCount: Int {
         get { TelemetryDeck.customDefaults?.integer(forKey: Self.deletedSessionsCountKey) ?? 0 }
@@ -60,11 +74,15 @@ final class SessionManager: @unchecked Sendable {
     }
 
     var averageSessionSeconds: Int {
-        guard self.recentSessions.count > 1 else {
-            return self.recentSessions.first?.durationInSeconds ?? -1
+        // Snapshot once: reading `recentSessions` repeatedly would take the lock each time and
+        // could observe a different array on every read.
+        let recentSessions = self.recentSessions
+
+        guard recentSessions.count > 1 else {
+            return recentSessions.first?.durationInSeconds ?? -1
         }
 
-        let completedSessions = self.recentSessions.dropLast()
+        let completedSessions = recentSessions.dropLast()
         let totalCompletedSessionSeconds = completedSessions.map(\.durationInSeconds).reduce(into: 0) { $0 += $1 }
         return totalCompletedSessionSeconds / completedSessions.count
     }
@@ -113,18 +131,19 @@ final class SessionManager: @unchecked Sendable {
 
     private let persistenceQueue = DispatchQueue(label: "com.telemetrydeck.sessionmanager.persistence")
 
-    private init() {
+    // Not `private` so tests can exercise an isolated instance instead of the shared singleton.
+    init() {
         if let existingSessionData = TelemetryDeck.customDefaults?.data(forKey: Self.recentSessionsKey),
             let existingSessions = try? Self.decoder.decode([StoredSession].self, from: existingSessionData)
         {
             // upon app start, clean up any sessions older than 90 days to keep dict small
             let cutoffDate = Date().addingTimeInterval(-(90 * 24 * 60 * 60))
-            self.recentSessions = existingSessions.filter { $0.startedAt > cutoffDate }
+            self.unsafeRecentSessions = existingSessions.filter { $0.startedAt > cutoffDate }
 
             // Update deleted sessions count
-            self.deletedSessionsCount += existingSessions.count - self.recentSessions.count
+            self.deletedSessionsCount += existingSessions.count - self.unsafeRecentSessions.count
         } else {
-            self.recentSessions = []
+            self.unsafeRecentSessions = []
         }
 
         self.updateDistinctDaysUsed()
@@ -169,8 +188,9 @@ final class SessionManager: @unchecked Sendable {
         self.sessionDurationLastUpdatedAt = nil
     }
 
+    // Not `private` so tests can drive a tick directly instead of waiting on the run-loop timer.
     @objc
-    private func updateSessionDuration() {
+    func updateSessionDuration() {
         if let sessionDurationLastUpdatedAt {
             self.currentSessionDuration += Date().timeIntervalSince(sessionDurationLastUpdatedAt)
         }
@@ -183,17 +203,31 @@ final class SessionManager: @unchecked Sendable {
         // Ignore sessions under 1 second
         guard self.currentSessionDuration >= 1.0 else { return }
 
-        // Add or update the current session
-        if let existingSessionIndex = self.recentSessions.lastIndex(where: { $0.startedAt == self.currentSessionStartedAt }) {
-            self.recentSessions[existingSessionIndex].durationInSeconds = Int(self.currentSessionDuration)
-        } else {
-            let newSession = StoredSession(startedAt: self.currentSessionStartedAt, durationInSeconds: Int(self.currentSessionDuration))
-            self.recentSessions.append(newSession)
-        }
+        let startedAt = self.currentSessionStartedAt
+        let durationInSeconds = Int(self.currentSessionDuration)
 
-        // Save changes to UserDefaults without blocking Main thread
+        // Update *and* save on the queue, without blocking the Main thread. Doing the mutation here
+        // rather than at the call site is what keeps this once-per-second bookkeeping off the run
+        // loop: previously the caller mutated the array while a queued encode still referenced it,
+        // so every tick both raced that encode and had to copy the whole array before it could
+        // mutate — which ThreadSanitizer flags, and which can crash or stall in `Array.subscript`.
         self.persistenceQueue.async {
-            if let updatedSessionData = try? Self.encoder.encode(self.recentSessions) {
+            self.sessionsLock.lock()
+
+            // Add or update the current session
+            if let existingSessionIndex = self.unsafeRecentSessions.lastIndex(where: { $0.startedAt == startedAt }) {
+                self.unsafeRecentSessions[existingSessionIndex].durationInSeconds = durationInSeconds
+            } else {
+                let newSession = StoredSession(startedAt: startedAt, durationInSeconds: durationInSeconds)
+                self.unsafeRecentSessions.append(newSession)
+            }
+
+            let updatedSessions = self.unsafeRecentSessions
+            self.sessionsLock.unlock()
+
+            // Encode outside the lock: the queue is serial, so this snapshot is released before the
+            // next tick runs and that tick can mutate the array in place.
+            if let updatedSessionData = try? Self.encoder.encode(updatedSessions) {
                 TelemetryDeck.customDefaults?.set(updatedSessionData, forKey: Self.recentSessionsKey)
             }
         }

--- a/Tests/TelemetryDeckTests/SessionManagerConcurrencyTests.swift
+++ b/Tests/TelemetryDeckTests/SessionManagerConcurrencyTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import TelemetryDeck
+
+/// Repro for https://github.com/TelemetryDeck/SwiftSDK/issues/236:
+///
+/// `persistCurrentSessionIfNeeded()` used to mutate `recentSessions` on the caller's thread — the
+/// once-per-second `updateSessionDuration` timer, plus the app lifecycle notifications — and then
+/// hand that same array to `persistenceQueue` to be JSON-encoded. The encode read the array while
+/// the next tick was already mutating it, so the two overlapped.
+///
+/// ThreadSanitizer reports that as a Swift access race. In the field it also surfaced as a crash or
+/// an app hang inside `Array.subscript.modify`, because the pending encode kept the buffer alive and
+/// every tick then had to copy the whole array on the main thread before it could mutate it.
+///
+/// Run with ThreadSanitizer enabled to catch the race itself; without a sanitizer these still assert
+/// that the session bookkeeping stays correct while ticks and reads overlap.
+///
+/// These deliberately avoid `startNewSession()` and `SessionManager.shared`: the former emits an
+/// internal signal that requires a globally initialized `TelemetryManager`, and both would leak
+/// state into other suites. Driving `updateSessionDuration()` directly exercises the same path.
+///
+/// Counts are asserted as deltas because `TelemetryDeck.customDefaults` is process-wide: whether it
+/// resolves to a real suite depends on whether another suite has initialized the SDK, so a manager
+/// may legitimately start with previously persisted sessions.
+@Suite(.serialized)
+struct SessionManagerConcurrencyTests {
+    /// `persistCurrentSessionIfNeeded()` ignores sessions under a second, so a tick only reaches the
+    /// array once the session has been running at least that long.
+    private static let minimumPersistableSessionDuration: TimeInterval = 1.05
+
+    /// Primes the duration bookkeeping and returns a manager whose next tick will persist.
+    private static func makeManagerReadyToPersist() -> SessionManager {
+        let manager = SessionManager()
+        manager.updateSessionDuration()
+        Thread.sleep(forTimeInterval: Self.minimumPersistableSessionDuration)
+        return manager
+    }
+
+    /// A tick hands the update to a private serial queue, so the count lands a hop later.
+    private static func sessionCount(
+        of manager: SessionManager,
+        settlingAt expected: Int,
+        timeout: TimeInterval = 2
+    ) -> Int {
+        let deadline = Date().addingTimeInterval(timeout)
+        var observed = manager.totalSessionsCount
+
+        while observed != expected, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+            observed = manager.totalSessionsCount
+        }
+
+        return observed
+    }
+
+    /// Drives ticks the way the run-loop timer does: serially, from a single thread. Each tick
+    /// updates the session and encodes it, so tick N+1 overlaps the encode still in flight for N.
+    @Test
+    func repeatedTicks_updateOneSessionWithoutRacingTheEncode() {
+        let manager = Self.makeManagerReadyToPersist()
+        let sessionsBefore = manager.totalSessionsCount
+
+        for _ in 0..<200 {
+            manager.updateSessionDuration()
+        }
+
+        #expect(
+            Self.sessionCount(of: manager, settlingAt: sessionsBefore + 1) == sessionsBefore + 1,
+            "ticks should keep updating one session, not append per tick"
+        )
+        #expect(manager.averageSessionSeconds >= 1)
+    }
+
+    /// The stats below are read by `DefaultSignalPayload.parameters` on every signal, i.e. from
+    /// whichever thread sends it, while the timer keeps updating the same array.
+    @Test
+    func concurrentStatReads_areConsistentWhileSessionUpdates() async {
+        if #available(iOS 16, macOS 13, tvOS 16, visionOS 1, watchOS 9, *) {
+            let manager = Self.makeManagerReadyToPersist()
+            let sessionsBefore = manager.totalSessionsCount
+
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for _ in 0..<200 {
+                        manager.updateSessionDuration()
+                    }
+                }
+
+                for _ in 0..<20 {
+                    group.addTask {
+                        _ = manager.averageSessionSeconds
+                        _ = manager.totalSessionsCount
+                        _ = manager.previousSessionSeconds
+                    }
+                }
+
+                await group.waitForAll()
+            }
+
+            #expect(Self.sessionCount(of: manager, settlingAt: sessionsBefore + 1) == sessionsBefore + 1)
+        } else {
+            print("skipping test on incompatible OS")
+        }
+    }
+}


### PR DESCRIPTION
Addresses #236.

## Problem

`persistCurrentSessionIfNeeded()` mutates `recentSessions` on the caller's thread — the once-per-second `updateSessionDuration` timer, plus the `didEnterBackground` / `willEnterForeground` handlers — and then hands that same array to `persistenceQueue` to be JSON-encoded:

```swift
self.recentSessions[existingSessionIndex].durationInSeconds = Int(self.currentSessionDuration)
…
self.persistenceQueue.async {
    if let updatedSessionData = try? Self.encoder.encode(self.recentSessions) { … }
}
```

That has two consequences:

1. **Data race.** The queued encode reads `recentSessions` while the next tick is already mutating it. This is the ThreadSanitizer report in #236, reproduced by several people on macOS since 2.9.x and still present on `main`.

2. **A copy-on-write copy on the main thread, once per second, for the life of the app.** Because the pending encode still references the buffer, the array is not uniquely referenced, so each tick's mutation has to copy the whole array before it can mutate it. The field reports in #236 land exactly there — `Array.subscript.modify` → `Array._makeMutableAndUnique` → `_ArrayBuffer._consumeAndCreateNew` — both as crashes and as app hangs.

There is currently no way for a consumer to opt out: `sessionStatsEnabled` only gates `startNewSession()`, while the `willBecomeActive` observer installed in `init()` schedules the timer regardless, and every signal instantiates the singleton via `DefaultSignalPayload.parameters`.

## Fix

Move the read-modify-write onto `persistenceQueue` and guard the array with a lock:

- `recentSessions` is now backed by `unsafeRecentSessions`, only touched while holding `sessionsLock`.
- `persistCurrentSessionIfNeeded()` captures the two scalars it needs and does the whole update inside the existing `persistenceQueue.async`, so the caller's thread does no array work at all.
- The lock is released **before** the JSON encode and the `UserDefaults` write, so a reader — `averageSessionSeconds` and friends, read on every signal from `DefaultSignalPayload.parameters`, which is `@MainActor` — can never end up blocked behind that I/O. This deliberately avoids reintroducing the shape of #265.
- Because the queue is serial, the snapshot taken for encoding is released before the next tick runs, so that tick mutates the array in place. The per-tick copy disappears rather than moving to the background.

## Behaviour change

The session update is applied one queue hop later instead of synchronously. The exposed stats are whole-second session durations refreshed once per second, so the lag is not observable in the reported values. Durability is unchanged — the `UserDefaults` write was already asynchronous.

## Tests

Adds `SessionManagerConcurrencyTests`, which drives ticks the way the run-loop timer does while the stats are read concurrently, and asserts the bookkeeping stays correct (one session updated per tick, not one appended per tick).

To keep it isolated it avoids `SessionManager.shared` and `startNewSession()` — the latter emits an internal signal that requires a globally initialized `TelemetryManager`. That needed two `private` → internal relaxations (`init`, `updateSessionDuration`), both commented at the declaration. Counts are asserted as deltas, because whether `TelemetryDeck.customDefaults` resolves to a real suite depends on whether another suite has initialized the SDK in the same process.

**Two caveats I'd rather state than have you discover:**

- These tests pass before *and* after the fix. I verified that explicitly by reverting the fix and re-running. They are regression guards and a deterministic repro vehicle for anyone running ThreadSanitizer — not a standalone failing test for the race.
- I could not verify under ThreadSanitizer locally: the sanitizer runtime refuses to load on my machine (`Sanitizer load violates platform policy`, macOS 26), and even a trivial suite crashes at bootstrap under it. The TSan reports in #236 remain the authoritative signal that the race is real; I'd appreciate confirmation from someone who can run TSan against this branch.

Verified: full suite green (68 tests), and the package builds for macOS, iOS and watchOS. tvOS/visionOS platforms aren't installed on my machine, but the change only uses `NSLock` and `DispatchQueue`.

## Related

#272 fixes a different defect in this file — session duration timers stacking up because `handleWillEnterForegroundNotification` replaces `sessionDurationUpdater` without invalidating the previous one. This PR does not touch the timer lifecycle, so the two are complementary rather than conflicting.
