### PR TITLE
Add support for events based on MetricKit reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Privacy-first analytics for Apple platforms. Send events to [TelemetryDeck](http
     * [Duration Tracking](#duration-tracking)
     * [Purchase Tracking](#purchase-tracking)
     * [Pirate Metrics (AARRR)](#pirate-metrics-aarrr)
+    * [MetricKit Reports](#metrickit-reports)
 * [Advanced](#advanced)
     * [Custom Salt](#custom-salt)
     * [Custom Server](#custom-server)
@@ -297,6 +298,18 @@ await TelemetryDeck.coreFeatureUsed(featureName: "export")
 await TelemetryDeck.referralSent(receiversCount: 3)
 await TelemetryDeck.paywallShown(reason: "feature-gate")
 ```
+
+### MetricKit Reports
+
+On iOS 27 / macOS 27 and later, forward a MetricKit `MetricReport` to TelemetryDeck:
+
+```swift
+if #available(iOS 27, macOS 27, *) {
+    await TelemetryDeck.send(metricReport: report)
+}
+```
+
+The report is sent as a single `TelemetryDeck.Performance.metricKitMetricReport` event with one parameter, `TelemetryDeck.Performance.metricKitMetricReport`, whose value is the report serialized to JSON.
 
 ## Advanced
 

--- a/Sources/TelemetryDeck/Capabilities/MetricReportProcessing.swift
+++ b/Sources/TelemetryDeck/Capabilities/MetricReportProcessing.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+#if canImport(MetricKit) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+    import MetricKit
+
+    /// An event processor that can convert a MetricKit performance report into a TelemetryDeck event.
+    @available(iOS 27, macOS 27, macCatalyst 27, *)
+    public protocol MetricReportProcessing: EventProcessor {
+        func send(metricReport: MetricReport) async
+    }
+#endif

--- a/Sources/TelemetryDeck/Events/DefaultEvents.swift
+++ b/Sources/TelemetryDeck/Events/DefaultEvents.swift
@@ -48,4 +48,9 @@ public enum DefaultEvents {
     public enum Error: String {
         case occurred = "TelemetryDeck.Error.occurred"
     }
+
+    /// Performance and MetricKit events.
+    public enum Performance: String {
+        case metricKitMetricReport = "TelemetryDeck.Performance.metricKitMetricReport"
+    }
 }

--- a/Sources/TelemetryDeck/Params/DefaultParams.swift
+++ b/Sources/TelemetryDeck/Params/DefaultParams.swift
@@ -138,6 +138,11 @@ public enum DefaultParams {
         case durationInSeconds = "TelemetryDeck.Signal.durationInSeconds"
     }
 
+    /// Performance report parameters.
+    public enum Performance: String {
+        case metricKitMetricReport = "TelemetryDeck.Performance.metricKitMetricReport"
+    }
+
     /// Display dimensions for connected screens.
     public enum Screens: String {
         case primaryWidth = "TelemetryDeck.Device.Screens.Primary.width"

--- a/Sources/TelemetryDeck/Presets/Performance.swift
+++ b/Sources/TelemetryDeck/Presets/Performance.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+#if canImport(MetricKit) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+    import MetricKit
+
+    extension TelemetryDeck {
+        /// Sends a MetricKit performance report as a single `TelemetryDeck.Performance.metricKitMetricReport` event.
+        ///
+        /// This must be called after `initialize()`;
+        @available(iOS 27, macOS 27, macCatalyst 27, *)
+        public static func send(metricReport: MetricReport) async {
+            guard let client = await client() else {
+                await log(.error, "TelemetryDeck not initialized")
+                return
+            }
+            guard let processor = await client.processor(conformingTo: (any MetricReportProcessing).self) else {
+                await log(.error, "No MetricReportProcessing processor in pipeline")
+                return
+            }
+            await processor.send(metricReport: metricReport)
+        }
+
+        /// Sends a MetricKit performance report without awaiting completion; suitable for fire-and-forget usage.
+        @available(iOS 27, macOS 27, macCatalyst 27, *)
+        public static func send(metricReport: MetricReport) {
+            Task { await send(metricReport: metricReport) }
+        }
+    }
+#endif

--- a/Sources/TelemetryDeck/Processors/MetricKitProcessor.swift
+++ b/Sources/TelemetryDeck/Processors/MetricKitProcessor.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+#if canImport(MetricKit) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+    import MetricKit
+
+    /// Converts MetricKit performance reports into a single `TelemetryDeck.Performance.metricKitMetricReport` event.
+    @available(iOS 27, macOS 27, macCatalyst 27, *)
+    public actor MetricKitProcessor: EventProcessor, MetricReportProcessing {
+        private var logger: (any Logging)?
+        private var emitter: (any EventSending)?
+
+        /// Creates a MetricKit processor.
+        public init() {}
+
+        /// Stores the logger and event emitter used when converting and sending reports.
+        public func start(storage: any ProcessorStorage, logger: any Logging, emitter: any EventSending) async {
+            self.logger = logger
+            self.emitter = emitter
+        }
+
+        /// Releases the logger and event emitter references.
+        public func stop() async {
+            logger = nil
+            emitter = nil
+        }
+
+        /// Passes events through unmodified.
+        public func process(
+            _ input: EventInput,
+            context: EventContext,
+            next: @Sendable (EventInput, EventContext) async throws -> Event
+        ) async throws -> Event {
+            try await next(input, context)
+        }
+
+        /// Serializes the given MetricKit report to JSON and sends it as the value of a single
+        /// `TelemetryDeck.Performance.metricKitMetricReport` parameter on a `TelemetryDeck.Performance.metricKitMetricReport` event.
+        public func send(metricReport report: MetricReport) async {
+            guard let emitter else {
+                logger?.log(.error, "MetricKitProcessor has not been started; dropping metric report")
+                return
+            }
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+            let reportData: Data
+            do {
+                reportData = try encoder.encode(report)
+            } catch {
+                logger?.log(.error, "Failed to encode metric report: \(error)")
+                return
+            }
+
+            let reportJSON = String(decoding: reportData, as: UTF8.self)
+
+            var parameters = EventParameters()
+            parameters[DefaultParams.Performance.metricKitMetricReport] = reportJSON
+
+            await emitter.send(
+                EventInput(
+                    DefaultEvents.Performance.metricKitMetricReport.rawValue,
+                    parameters: parameters,
+                    skipsReservedPrefixValidation: true
+                )
+            )
+        }
+    }
+#endif

--- a/Sources/TelemetryDeck/TelemetryDeck.swift
+++ b/Sources/TelemetryDeck/TelemetryDeck.swift
@@ -87,7 +87,7 @@ public enum TelemetryDeck {
         parameterPrefix: String?,
         defaultParameters: EventParameters
     ) -> [any EventProcessor] {
-        [
+        var processors: [any EventProcessor] = [
             PreviewFilterProcessor(),
             DefaultParametersProcessor(parameters: defaultParameters),
             DefaultPrefixProcessor(eventPrefix: eventPrefix, parameterPrefix: parameterPrefix),
@@ -102,6 +102,14 @@ public enum TelemetryDeck {
             AccessibilityProcessor(),
             DisplayProcessor(),
         ]
+
+        #if canImport(MetricKit) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+            if #available(iOS 27, macOS 27, macCatalyst 27, *) {
+                processors.append(MetricKitProcessor())
+            }
+        #endif
+
+        return processors
     }
 
     /// Initialises the SDK with the given app identity and processor-level options.

--- a/Tests/TelemetryDeckTests/MetricKitProcessorTests.swift
+++ b/Tests/TelemetryDeckTests/MetricKitProcessorTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import TelemetryDeck
+
+#if canImport(MetricKit) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+    import MetricKit
+
+    @Suite
+    struct MetricKitProcessorTests {
+        private static let fixtureJSON = """
+            {
+              "timeRange": {"begin": 0, "end": 3600},
+              "stateEntries": [
+                {
+                  "state": {
+                    "domain": "com.telemetrydeck.feature",
+                    "label": "premium",
+                    "duration": {"value": 120.0, "unit": "s"},
+                    "stableMetadata": {}
+                  },
+                  "values": [
+                    {"cpuTimeMetric": {"value": {"value": 5.0, "unit": "s"}}}
+                  ]
+                }
+              ],
+              "intervalEntries": [
+                {
+                  "states": [],
+                  "duration": {"value": 86400.0, "unit": "s"},
+                  "values": [
+                    {"cpuTimeMetric": {"value": {"value": 42.0, "unit": "s"}}},
+                    {
+                      "hangTimeMetric": {
+                        "histogram": {
+                          "buckets": [
+                            {"lowerBound": {"value": 0.0, "unit": "s"}, "upperBound": {"value": 1.0, "unit": "s"}, "count": 5}
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """
+
+        @available(iOS 27, macOS 27, macCatalyst 27, *)
+        private static func makeFixtureReport() throws -> MetricReport {
+            try JSONDecoder().decode(MetricReport.self, from: Data(fixtureJSON.utf8))
+        }
+
+        @Test
+        @available(iOS 27, macOS 27, macCatalyst 27, *)
+        func sendMetricReportEmitsSingleEvent() async throws {
+            let report = try Self.makeFixtureReport()
+            let processor = MetricKitProcessor()
+            let emitter = CapturingEventSender()
+            await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: emitter)
+
+            await processor.send(metricReport: report)
+
+            let sentEvents = await emitter.sentEvents
+            #expect(sentEvents.count == 1)
+            #expect(sentEvents.first?.name == DefaultEvents.Performance.metricKitMetricReport.rawValue)
+        }
+
+        @Test
+        @available(iOS 27, macOS 27, macCatalyst 27, *)
+        func sendMetricReportIncludesSingleJSONParameter() async throws {
+            let report = try Self.makeFixtureReport()
+            let processor = MetricKitProcessor()
+            let emitter = CapturingEventSender()
+            await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: emitter)
+
+            await processor.send(metricReport: report)
+
+            let event = try #require(await emitter.sentEvents.first)
+            #expect(event.parameters.count == 1)
+
+            let value = try #require(event.parameters[DefaultParams.Performance.metricKitMetricReport.rawValue]?.payloadValue)
+            let jsonValue: String? = if case .string(let string) = value { string } else { nil }
+            let json = try #require(jsonValue)
+
+            let decodedReport = try JSONDecoder().decode(MetricReport.self, from: Data(json.utf8))
+            #expect(decodedReport.stateEntries.count == 1)
+            #expect(decodedReport.stateEntries.first?.state.domain == "com.telemetrydeck.feature")
+
+            let cpuTimeValues = decodedReport.intervalEntries.fullDayEntry.values.compactMap { value -> Measurement<UnitDuration>? in
+                guard case .cpuTime(let metric) = value else { return nil }
+                return metric.value
+            }
+            let cpuTimeValue = try #require(cpuTimeValues.first)
+            #expect(cpuTimeValue.converted(to: .baseUnit()).value == 42.0)
+        }
+
+        @Test
+        @available(iOS 27, macOS 27, macCatalyst 27, *)
+        func sendMetricReportWithoutStartDropsReport() async throws {
+            let report = try Self.makeFixtureReport()
+            let processor = MetricKitProcessor()
+
+            await processor.send(metricReport: report)
+
+            let emitter = CapturingEventSender()
+            await processor.start(storage: InMemoryProcessorStorage(), logger: NoOpLogger(), emitter: emitter)
+            await processor.send(metricReport: report)
+
+            let sentEvents = await emitter.sentEvents
+            #expect(sentEvents.count == 1)
+        }
+    }
+#endif


### PR DESCRIPTION
This PR adds the ability to submit MetricKit reports: 

```swift
 await TelemetryDeck.send(metricReport: report)
```

The report is converted into a single `TelemetryDeck.Performance.metricKitMetricReport` event with one parameter per metric, named `TelemetryDeck.Performance.metricKitMetricReport` containing the JSON representation of the metric report.

Note: the app is responsible for instantiating a `MetricManager` and consuming the `manager.metricReports` 


The feature is enabled by default on platforms where MetricKit is available via a new `MetricKitProcessor`.